### PR TITLE
Feat: TV 시리즈 API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { PreferenceModule } from './preference/preference.module';
 import { ConfigModule } from '@nestjs/config';
 import { MovieModule } from './movie/movie.module';
 import { DatabaseModule } from './common/database/database.module';
+import { TvModule } from './tv/tv.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { DatabaseModule } from './common/database/database.module';
     AuthModule,
     UserModule,
     MovieModule,
+    TvModule,
     CollectionModule,
     CollectionContentsModule,
     GenreModule,

--- a/src/common/utils/tmdb.utils.ts
+++ b/src/common/utils/tmdb.utils.ts
@@ -1,13 +1,9 @@
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
+import { ConfigService } from '@nestjs/config';
 
 const TMDB_BASE_URL = 'https://api.themoviedb.org/3';
 const DEFAULT_LANGUAGE = 'ko-KR';
-
-const TMDB_AUTH_HEADER = {
-  Authorization: `Bearer ${process.env.TMDB_ACCESS_TOKEN}`,
-  accept: 'application/json',
-};
 
 export function buildTmdbUrl(
   path: string,
@@ -29,10 +25,19 @@ export function buildTmdbUrl(
 export async function fetchFromTmdb<T>(
   httpService: HttpService,
   url: string,
+  configService: ConfigService,
 ): Promise<T> {
+  const token = configService.get<string>('TMDB_ACCESS_TOKEN');
+  if (!token) {
+    throw new Error('TMDB_ACCESS_TOKEN not found in environment variables');
+  }
+
   const response = await firstValueFrom(
     httpService.get<T>(url, {
-      headers: TMDB_AUTH_HEADER,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        accept: 'application/json',
+      },
     }),
   );
   return response.data;

--- a/src/movie/movie.service.ts
+++ b/src/movie/movie.service.ts
@@ -5,10 +5,14 @@ import { FindMovieListResponseDto } from './dto/find-movie-list-response.dto';
 import { FindMovieDetailResponseDto } from './dto/find-movie-detail-response.dto';
 import { TMDBMovieDetailResponse } from './interfaces/movie.interface';
 import { buildTmdbUrl, fetchFromTmdb } from '../common/utils/tmdb.utils';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class MovieService {
-  constructor(private readonly httpService: HttpService) {}
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly configService: ConfigService,
+  ) {}
 
   // 영화 상세 정보 조회
   async getMovieById(id: number): Promise<FindMovieDetailResponseDto> {
@@ -16,6 +20,7 @@ export class MovieService {
     const tmdbResponse = await fetchFromTmdb<TMDBMovieDetailResponse>(
       this.httpService,
       url,
+      this.configService,
     );
     return FindMovieDetailResponseDto.fromTMDB(tmdbResponse);
   }
@@ -26,6 +31,7 @@ export class MovieService {
     const tmdbResponse = await fetchFromTmdb<TMDBNowPlayingResponse>(
       this.httpService,
       url,
+      this.configService,
     );
     return FindMovieListResponseDto.fromTMDBResponse(tmdbResponse);
   }
@@ -36,6 +42,7 @@ export class MovieService {
     const tmdbResponse = await fetchFromTmdb<TMDBNowPlayingResponse>(
       this.httpService,
       url,
+      this.configService,
     );
     return FindMovieListResponseDto.fromTMDBResponse(tmdbResponse);
   }
@@ -52,6 +59,7 @@ export class MovieService {
     const tmdbResponse = await fetchFromTmdb<TMDBNowPlayingResponse>(
       this.httpService,
       url,
+      this.configService,
     );
     return FindMovieListResponseDto.fromTMDBResponse(tmdbResponse);
   }
@@ -67,6 +75,7 @@ export class MovieService {
     const tmdbResponse = await fetchFromTmdb<TMDBNowPlayingResponse>(
       this.httpService,
       url,
+      this.configService,
     );
     return FindMovieListResponseDto.fromTMDBResponse(tmdbResponse);
   }

--- a/src/tv/dto/find-tv-detail-response.dto.ts
+++ b/src/tv/dto/find-tv-detail-response.dto.ts
@@ -1,0 +1,113 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsOptional } from 'class-validator';
+import {
+  TMDBGenre,
+  TMDBTvDetailResponse,
+  TMDBTvSeason,
+} from '../interfaces/tv.interface';
+
+export class FindTvDetailResponseDto {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  title: string;
+
+  @ApiProperty()
+  overview: string;
+
+  @ApiProperty({ nullable: true })
+  @IsOptional()
+  poster_path: string | null;
+
+  @ApiProperty({ nullable: true })
+  @IsOptional()
+  backdrop_path: string | null;
+
+  @ApiProperty()
+  adult: boolean;
+
+  @ApiProperty()
+  original_language: string;
+
+  @ApiProperty({ type: [String] })
+  languages: string[];
+
+  @ApiProperty()
+  in_production: boolean;
+
+  @ApiProperty({ type: [Object] })
+  genres: { id: number; name: string }[];
+
+  @ApiProperty()
+  status: string;
+
+  @ApiProperty({ nullable: true })
+  @IsOptional()
+  first_air_date: string | null;
+
+  @ApiProperty({ nullable: true })
+  @IsOptional()
+  last_air_date: string | null;
+
+  @ApiProperty()
+  popularity: number;
+
+  @ApiProperty()
+  vote_average: number;
+
+  @ApiProperty()
+  vote_count: number;
+
+  @ApiProperty()
+  number_of_seasons: number;
+
+  @ApiProperty()
+  number_of_episodes: number;
+
+  @ApiProperty({ type: [Object] })
+  @IsArray()
+  seasons: {
+    id: number;
+    season_number: number;
+    episode_count: number;
+    poster_path: string | null;
+    air_date: string | null;
+    name: string;
+    title: string;
+    vote_average: number;
+  }[];
+
+  static fromTMDB(raw: TMDBTvDetailResponse): FindTvDetailResponseDto {
+    return {
+      id: raw.id,
+      title: raw.name,
+      overview: raw.overview,
+      poster_path: raw.poster_path,
+      backdrop_path: raw.backdrop_path,
+      adult: raw.adult,
+      original_language: raw.original_language,
+      languages: raw.languages,
+      in_production: raw.in_production,
+      genres: raw.genres.map((g: TMDBGenre) => ({ id: g.id, name: g.name })),
+      status: raw.status,
+      first_air_date: raw.first_air_date,
+      last_air_date: raw.last_air_date,
+      popularity: raw.popularity,
+      vote_average: raw.vote_average,
+      vote_count: raw.vote_count,
+      number_of_seasons: raw.number_of_seasons,
+      number_of_episodes: raw.number_of_episodes,
+      seasons: raw.seasons.map((s: TMDBTvSeason) => ({
+        id: s.id,
+        season_number: s.season_number,
+        episode_count: s.episode_count,
+        poster_path: s.poster_path,
+        air_date: s.air_date,
+        name: s.name,
+        title: s.name,
+        vote_average: s.vote_average,
+      })),
+    };
+  }
+}

--- a/src/tv/dto/find-tv-list-response.dto.ts
+++ b/src/tv/dto/find-tv-list-response.dto.ts
@@ -1,0 +1,48 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsNumber, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { TvListItemDto } from './tv-list-item.dto';
+import { TMDBTvListResponse } from '../interfaces/tv-list.interface';
+
+export class FindTvListResponseDto {
+  @ApiProperty({
+    description: '조회된 TV 프로그램 목록',
+    type: [TvListItemDto],
+    example: [
+      {
+        id: 1396,
+        poster_path: '/ztkUQFLlC19CCMYHW9o1zWhJRNq.jpg',
+        title: '브레이킹 배드',
+      },
+      {
+        id: 1398,
+        poster_path: '/rTc7ZXdroqjkKivFPvCPX0Ru7uw.jpg',
+        title: '더 소프라노스',
+      },
+    ],
+  })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => TvListItemDto)
+  tvs: TvListItemDto[];
+
+  @ApiProperty({ description: '현재 페이지 번호', example: 1 })
+  @IsNumber()
+  page: number;
+
+  @ApiProperty({ description: '총 페이지 수', example: 1000 })
+  @IsNumber()
+  totalPages: number;
+
+  constructor(tvs: TvListItemDto[], page: number, totalPages: number) {
+    this.tvs = tvs;
+    this.page = page;
+    this.totalPages = totalPages;
+  }
+
+  static fromTMDBResponse(raw: TMDBTvListResponse): FindTvListResponseDto {
+    const tvs = raw.results.map((tvItem) => TvListItemDto.fromTMDB(tvItem));
+
+    return new FindTvListResponseDto(tvs, raw.page, raw.total_pages);
+  }
+}

--- a/src/tv/dto/tv-list-item.dto.ts
+++ b/src/tv/dto/tv-list-item.dto.ts
@@ -1,0 +1,13 @@
+import { TMDBTvItem } from '../interfaces/tv-list.interface';
+
+export class TvListItemDto {
+  constructor(
+    public id: number,
+    public title: string,
+    public poster_path: string,
+  ) {}
+
+  static fromTMDB(raw: TMDBTvItem): TvListItemDto {
+    return new TvListItemDto(raw.id, raw.name, raw.poster_path);
+  }
+}

--- a/src/tv/interfaces/tv-list.interface.ts
+++ b/src/tv/interfaces/tv-list.interface.ts
@@ -1,0 +1,23 @@
+export interface TMDBTvItem {
+  adult: boolean;
+  backdrop_path: string;
+  genre_ids: number[];
+  id: number;
+  origin_country: string[];
+  original_language: string;
+  original_name: string;
+  overview: string;
+  popularity: number;
+  poster_path: string;
+  first_air_date: string;
+  name: string;
+  vote_average: number;
+  vote_count: number;
+}
+
+export interface TMDBTvListResponse {
+  page: number;
+  results: TMDBTvItem[];
+  total_pages: number;
+  total_results: number;
+}

--- a/src/tv/interfaces/tv.interface.ts
+++ b/src/tv/interfaces/tv.interface.ts
@@ -1,0 +1,92 @@
+export interface TMDBGenre {
+  id: number;
+  name: string;
+}
+
+export interface TMDBProductionCompany {
+  id: number;
+  logo_path: string | null;
+  name: string;
+  origin_country: string;
+}
+
+export interface TMDBProductionCountry {
+  iso_3166_1: string;
+  name: string;
+}
+
+export interface TMDBSpokenLanguage {
+  english_name: string;
+  iso_639_1: string;
+  name: string;
+}
+
+export interface TMDBTvCreatedBy {
+  id: number;
+  credit_id: string;
+  name: string;
+  gender: number;
+  profile_path: string | null;
+}
+
+export interface TMDBTvEpisodeToAir {
+  id: number;
+  name: string;
+  overview: string;
+  vote_average: number;
+  vote_count: number;
+  air_date: string;
+  episode_number: number;
+  episode_type: string;
+  production_code: string;
+  runtime: number | null;
+  season_number: number;
+  show_id: number;
+  still_path: string | null;
+}
+
+export interface TMDBTvSeason {
+  air_date: string | null;
+  episode_count: number;
+  id: number;
+  name: string;
+  overview: string;
+  poster_path: string | null;
+  season_number: number;
+  vote_average: number;
+}
+
+export interface TMDBTvDetailResponse {
+  adult: boolean;
+  backdrop_path: string | null;
+  created_by: TMDBTvCreatedBy[];
+  episode_run_time: number[];
+  first_air_date: string;
+  genres: TMDBGenre[];
+  homepage: string | null;
+  id: number;
+  in_production: boolean;
+  languages: string[];
+  last_air_date: string | null;
+  last_episode_to_air: TMDBTvEpisodeToAir | null;
+  name: string;
+  next_episode_to_air: TMDBTvEpisodeToAir | null;
+  networks: any[];
+  number_of_episodes: number;
+  number_of_seasons: number;
+  origin_country: string[];
+  original_language: string;
+  original_name: string;
+  overview: string;
+  popularity: number;
+  poster_path: string | null;
+  production_companies: TMDBProductionCompany[];
+  production_countries: TMDBProductionCountry[];
+  seasons: TMDBTvSeason[];
+  spoken_languages: TMDBSpokenLanguage[];
+  status: string;
+  tagline: string;
+  type: string;
+  vote_average: number;
+  vote_count: number;
+}

--- a/src/tv/tv.controller.ts
+++ b/src/tv/tv.controller.ts
@@ -1,0 +1,74 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { TvService } from './tv.service';
+import { FindTvListResponseDto } from './dto/find-tv-list-response.dto';
+import { FindTvDetailResponseDto } from './dto/find-tv-detail-response.dto';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Public } from '../auth/decorators/public.decorator';
+
+@Controller('tvs')
+@ApiTags('Tvs')
+export class TvController {
+  constructor(private readonly tvService: TvService) {}
+
+  @Public()
+  @Get('now-playing')
+  @ApiOperation({
+    summary: '상영 중인 TV 시리즈 리스트를 조회',
+    description: '현재 상영 중인 TV 시리즈 리스트를 조회합니다.',
+  })
+  async getNowPlayingTv(
+    @Query('page') page?: number,
+  ): Promise<FindTvListResponseDto> {
+    return this.tvService.getNowPlayingTvs(page);
+  }
+
+  @Public()
+  @Get('top-rated')
+  @ApiOperation({
+    summary: '평점 높은 TV 시리즈 리스트 조회',
+    description: '평점이 높은 TV 시리즈 리스트를 조회합니다.',
+  })
+  async getTopRatedTv(
+    @Query('page') page?: number,
+  ): Promise<FindTvListResponseDto> {
+    return this.tvService.getTopRatedTvs(page);
+  }
+
+  @Public()
+  @Get(':tvId')
+  @ApiOperation({
+    summary: 'TV 시리즈 상세 정보 조회',
+    description: 'TV 시리즈 ID를 통해 TV 시리즈의 상세 정보를 조회합니다.',
+  })
+  async getTvById(
+    @Param('tvId') tvId: number,
+  ): Promise<FindTvDetailResponseDto> {
+    return this.tvService.getTvById(tvId);
+  }
+
+  @Public()
+  @Get('')
+  @ApiOperation({
+    summary: '장르별 TV 시리즈 리스트 조회',
+    description: '장르 ID를 통해 해당 장르의 TV 시리즈 리스트를 조회합니다.',
+  })
+  async getTvsByGenre(
+    @Query('genreId') genreId: number,
+    @Query('page') page?: number,
+  ): Promise<FindTvListResponseDto> {
+    return this.tvService.getTvsByGenre(genreId, page);
+  }
+
+  @Public()
+  @Get(':tvId/recommends')
+  @ApiOperation({
+    summary: '추천 TV 시리즈 리스트 조회',
+    description: 'TV 시리즈 ID를 통해 추천 TV 시리즈 리스트를 조회합니다.',
+  })
+  async getRecommendedTvsById(
+    @Param('tvId') tvId: number,
+    @Query('page') page?: number,
+  ): Promise<FindTvListResponseDto> {
+    return this.tvService.getRecommendedTvsById(tvId, page);
+  }
+}

--- a/src/tv/tv.controller.ts
+++ b/src/tv/tv.controller.ts
@@ -3,14 +3,12 @@ import { TvService } from './tv.service';
 import { FindTvListResponseDto } from './dto/find-tv-list-response.dto';
 import { FindTvDetailResponseDto } from './dto/find-tv-detail-response.dto';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
-import { Public } from '../auth/decorators/public.decorator';
 
 @Controller('tvs')
 @ApiTags('Tvs')
 export class TvController {
   constructor(private readonly tvService: TvService) {}
 
-  @Public()
   @Get('now-playing')
   @ApiOperation({
     summary: '상영 중인 TV 시리즈 리스트를 조회',
@@ -22,7 +20,6 @@ export class TvController {
     return this.tvService.getNowPlayingTvs(page);
   }
 
-  @Public()
   @Get('top-rated')
   @ApiOperation({
     summary: '평점 높은 TV 시리즈 리스트 조회',
@@ -34,7 +31,6 @@ export class TvController {
     return this.tvService.getTopRatedTvs(page);
   }
 
-  @Public()
   @Get(':tvId')
   @ApiOperation({
     summary: 'TV 시리즈 상세 정보 조회',
@@ -46,7 +42,6 @@ export class TvController {
     return this.tvService.getTvById(tvId);
   }
 
-  @Public()
   @Get('')
   @ApiOperation({
     summary: '장르별 TV 시리즈 리스트 조회',
@@ -59,7 +54,6 @@ export class TvController {
     return this.tvService.getTvsByGenre(genreId, page);
   }
 
-  @Public()
   @Get(':tvId/recommends')
   @ApiOperation({
     summary: '추천 TV 시리즈 리스트 조회',

--- a/src/tv/tv.module.ts
+++ b/src/tv/tv.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TvController } from './tv.controller';
+import { TvService } from './tv.service';
+import { HttpModule } from '@nestjs/axios';
+
+@Module({
+  imports: [HttpModule],
+  controllers: [TvController],
+  providers: [TvService],
+})
+export class TvModule {}

--- a/src/tv/tv.service.ts
+++ b/src/tv/tv.service.ts
@@ -1,0 +1,82 @@
+import { ConfigService } from '@nestjs/config';
+import { HttpService } from '@nestjs/axios';
+import { Injectable } from '@nestjs/common';
+import { FindTvListResponseDto } from './dto/find-tv-list-response.dto';
+import { FindTvDetailResponseDto } from './dto/find-tv-detail-response.dto';
+import { TMDBTvDetailResponse } from './interfaces/tv.interface';
+import { TMDBTvListResponse } from './interfaces/tv-list.interface';
+import { buildTmdbUrl, fetchFromTmdb } from '../common/utils/tmdb.utils';
+
+@Injectable()
+export class TvService {
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  // TV 시리즈 상세 정보 조회
+  async getTvById(id: number): Promise<FindTvDetailResponseDto> {
+    const url = buildTmdbUrl(`/tv/${id}`);
+    const tmdbResponse = await fetchFromTmdb<TMDBTvDetailResponse>(
+      this.httpService,
+      url,
+      this.configService,
+    );
+    return FindTvDetailResponseDto.fromTMDB(tmdbResponse);
+  }
+
+  // 상영 중인 TV 시리즈 조회
+  async getNowPlayingTvs(page = 1): Promise<FindTvListResponseDto> {
+    const url = buildTmdbUrl('/tv/on_the_air', { page });
+    const tmdbResponse = await fetchFromTmdb<TMDBTvListResponse>(
+      this.httpService,
+      url,
+      this.configService,
+    );
+    return FindTvListResponseDto.fromTMDBResponse(tmdbResponse);
+  }
+
+  // 평점 높은 TV 시리즈 조회
+  async getTopRatedTvs(page = 1): Promise<FindTvListResponseDto> {
+    const url = buildTmdbUrl('/tv/top_rated', { page });
+    const tmdbResponse = await fetchFromTmdb<TMDBTvListResponse>(
+      this.httpService,
+      url,
+      this.configService,
+    );
+    return FindTvListResponseDto.fromTMDBResponse(tmdbResponse);
+  }
+
+  // 특정 장르 TV 시리즈 조회
+  async getTvsByGenre(
+    genreId: number,
+    page = 1,
+  ): Promise<FindTvListResponseDto> {
+    const url = buildTmdbUrl('/discover/tv', {
+      with_genres: genreId,
+      page: page,
+    });
+    const tmdbResponse = await fetchFromTmdb<TMDBTvListResponse>(
+      this.httpService,
+      url,
+      this.configService,
+    );
+    return FindTvListResponseDto.fromTMDBResponse(tmdbResponse);
+  }
+
+  // 추천 TV 시리즈 조회
+  async getRecommendedTvsById(
+    tvId: number,
+    page = 1,
+  ): Promise<FindTvListResponseDto> {
+    const url = buildTmdbUrl(`/tv/${tvId}/recommendations`, {
+      page: page,
+    });
+    const tmdbResponse = await fetchFromTmdb<TMDBTvListResponse>(
+      this.httpService,
+      url,
+      this.configService,
+    );
+    return FindTvListResponseDto.fromTMDBResponse(tmdbResponse);
+  }
+}


### PR DESCRIPTION
## 개요

- TV 시리즈 관련 API 를 구현했습니다.

## 작업사항

- **TMDB 외부 API 응답 타입 정의**
  - TMDB API에서 받아오는 TV 시리즈 리스트 및 상세 정보의 구조를 명확하게 정의하기 위한 인터페이스를 추가했습니다.
- **응답 DTO 정의**
  - TV 시리즈 리스트 (`FindTvListResponseDto`) 및 상세 정보 (`FindTvDetailResponseDto`) 응답 DTO를 정의했습니다.
- **TV 시리즈 조회 API 구현**
  - TV 시리즈 상세 정보 조회 API를 구현했습니다.
  - 상영 중인 TV 시리즈 목록, 평점 높은 TV 시리즈 목록, 장르별 TV 시리즈 목록, 추천 TV 시리즈 목록 조회 API를 구현했습니다.
- **TMDB 외부 API 관련 유틸 함수 수정**
  - 환경변수를 관리할 때 `ConfigService`에서 주입받아 사용할 수 있도록 수정했습니다.

## 주의사항

- 기존 환경변수를 직접 읽어오는 방식에서 ConfigService로 주입받도록 유틸함수를 수정하였습니다.
- 기존 Movie와 중복되는 인터페이스는 리팩토링 시 상위 폴더에 묶어서 각자 사용할 수 있도록 수정할 예정입니다.
  - 이를 위해 `tv/`, `movie/`를 `contents/` 하위로 위치시키는 방안을 고려해볼 것입니다.
- 커스텀 예외처리는 추후에 다른 브랜치에서 작업 예정입니다.
