### PR TITLE
Feat: 사용자 취향 설정 및 조회 API 구현

### DIFF
--- a/src/common/dto/content-list-query-dto.ts
+++ b/src/common/dto/content-list-query-dto.ts
@@ -1,0 +1,17 @@
+import { Transform } from 'class-transformer';
+import { IsArray, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { PaginationQueryDto } from './pagination-query.dto';
+
+export class ContentListQueryDto extends PaginationQueryDto {
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  @IsNotEmpty({ message: 'genreId는 비어있을 수 없습니다.' })
+  @Transform(({ value }) => {
+    if (typeof value === 'string') {
+      return value.split(',');
+    }
+    return value;
+  })
+  genreId: string[];
+}

--- a/src/common/dto/pagination-query.dto.ts
+++ b/src/common/dto/pagination-query.dto.ts
@@ -1,0 +1,10 @@
+import { Type } from 'class-transformer';
+import { IsNumber, IsOptional, Min } from 'class-validator';
+
+export class PaginationQueryDto {
+  @IsOptional()
+  @IsNumber({}, { message: 'page는 숫자여야 합니다.' })
+  @Min(1, { message: 'page는 1 이상이어야 합니다' })
+  @Type(() => Number)
+  page?: number;
+}

--- a/src/common/utils/tmdb.utils.ts
+++ b/src/common/utils/tmdb.utils.ts
@@ -1,8 +1,7 @@
-import type { HttpService } from '@nestjs/axios';
-import type { ConfigService } from '@nestjs/config';
-import type { AxiosError } from 'axios';
+import { HttpService } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
 import { firstValueFrom } from 'rxjs';
-import type { TmdbErrorResponse } from '../interfaces/tmdb-error.interface';
+import { ExternalApiException } from '../exceptions/external-api-exception';
 
 const TMDB_BASE_URL = 'https://api.themoviedb.org/3';
 const DEFAULT_LANGUAGE = 'ko-KR';
@@ -18,17 +17,17 @@ export function buildTmdbUrl(
     }
   }
 
-  processedQuery['language'] = processedQuery['language'] || DEFAULT_LANGUAGE;
+  processedQuery.language = processedQuery.language || DEFAULT_LANGUAGE;
 
   const queryString = new URLSearchParams(processedQuery).toString();
-  return `${TMDB_BASE_URL}${path}${queryString ? '?' + queryString : ''}`;
+  return `${TMDB_BASE_URL}${path}${queryString ? `?${queryString}` : ''}`;
 }
 
 export async function fetchFromTmdb<T>(
   httpService: HttpService,
   url: string,
   configService: ConfigService,
-): Promise<{ data?: T; error?: TmdbErrorResponse }> {
+): Promise<T> {
   const token = configService.get<string>('TMDB_ACCESS_TOKEN');
   if (!token) {
     throw new Error('TMDB_ACCESS_TOKEN not found in environment variables');
@@ -43,10 +42,8 @@ export async function fetchFromTmdb<T>(
         },
       }),
     );
-    return { data: response.data };
-  } catch (error) {
-    const axiosError = error as AxiosError;
-    const errorData = axiosError.response?.data as TmdbErrorResponse;
-    return { error: errorData };
+    return response.data;
+  } catch (_error) {
+    throw new ExternalApiException();
   }
 }

--- a/src/genre/dto/genre.dto.ts
+++ b/src/genre/dto/genre.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
 import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { Genre } from './../entity/genre.entity';
 
 export class GenreDto {
   @ApiProperty({ example: 1, description: '장르 ID' })
@@ -19,4 +20,12 @@ export class GenreDto {
   @IsString()
   @Expose()
   emoji: string;
+
+  static of(genre: Genre): GenreDto {
+    return {
+      id: genre.id,
+      name: genre.name,
+      emoji: genre.emoji,
+    };
+  }
 }

--- a/src/genre/genre.module.ts
+++ b/src/genre/genre.module.ts
@@ -10,6 +10,7 @@ import { GenreService } from './genre.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Genre]), HttpModule, ConfigModule],
+  exports: [GenreService],
   controllers: [GenreController],
   providers: [GenreRepository, GenreService],
 })

--- a/src/genre/genre.repository.ts
+++ b/src/genre/genre.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ContentType } from 'src/common/types/content-type.enum';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { TMDBGenre } from '../common/interfaces/tmdb-common.interface';
 import { Genre } from './entity/genre.entity';
@@ -62,6 +62,14 @@ export class GenreRepository {
         '여러 장르 저장 중 오류가 발생했습니다.',
       );
     }
+  }
+
+  async findByIds(ids: string[]): Promise<Genre[]> {
+    return this.repository.find({
+      where: {
+        id: In(ids),
+      },
+    });
   }
 
   async findByContentType(contentType: ContentType): Promise<Genre[]> {

--- a/src/movie/dto/find-movie-detail-response.dto.ts
+++ b/src/movie/dto/find-movie-detail-response.dto.ts
@@ -5,6 +5,9 @@ export class FindMovieDetailResponseDto {
   @ApiProperty({ description: '영화의 고유 ID', example: 574475 })
   id: number;
 
+  @ApiProperty({ description: '콘텐츠 유형', example: 'movie' })
+  contentType: string;
+
   @ApiProperty({
     description: '영화 제목',
     example: '파이널 데스티네이션 블러드라인스',
@@ -77,6 +80,7 @@ export class FindMovieDetailResponseDto {
   static of(raw: TMDBMovieDetailResponse): FindMovieDetailResponseDto {
     return {
       id: raw.id,
+      contentType: 'movie',
       title: raw.title,
       overview: raw.overview,
       posterPath: raw.poster_path,

--- a/src/movie/dto/find-movie-list-response.dto.ts
+++ b/src/movie/dto/find-movie-list-response.dto.ts
@@ -4,6 +4,12 @@ import { MovieListItemDto } from './movie-list-item.dto';
 
 export class FindMovieListResponseDto {
   @ApiProperty({
+    description: '콘텐츠 유형',
+    example: 'movie',
+  })
+  contentType: string;
+
+  @ApiProperty({
     description: '조회된 영화 목록',
     type: [MovieListItemDto],
     example: [
@@ -31,6 +37,7 @@ export class FindMovieListResponseDto {
 
   static of(raw: TMDBNowPlayingResponse): FindMovieListResponseDto {
     return {
+      contentType: 'movie',
       movies: raw.results.map(MovieListItemDto.of),
       page: raw.page,
       totalPages: raw.total_pages,

--- a/src/movie/movie.controller.ts
+++ b/src/movie/movie.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { Controller, Get, Param, ParseArrayPipe, Query } from '@nestjs/common';
 import {
   ApiOkResponse,
   ApiOperation,
@@ -110,8 +110,11 @@ export class MovieController {
     InvalidPageException,
   ])
   async getMoviesByGenre(
-    @Query('genreId') genreId: number,
-    @Query('page') page?: number,
+    @Query('genreId', new ParseArrayPipe({ items: String, optional: true }))
+    genreId: string[],
+
+    @Query('page')
+    page?: number,
   ): Promise<FindMovieListResponseDto> {
     return this.movieService.getMoviesByGenre(genreId, page);
   }

--- a/src/movie/movie.controller.ts
+++ b/src/movie/movie.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, ParseArrayPipe, Query } from '@nestjs/common';
+import { Controller, Get, Param, Query } from '@nestjs/common';
 import {
   ApiOkResponse,
   ApiOperation,
@@ -11,6 +11,8 @@ import { ContentNotFoundException } from 'src/common/exceptions/content-not-foun
 import { ExternalApiException } from 'src/common/exceptions/external-api-exception';
 import { InvalidGenreIdException } from 'src/common/exceptions/invalid-genre-id.exception';
 import { InvalidPageException } from 'src/common/exceptions/invalid-page.exception';
+import { ContentListQueryDto } from './../common/dto/content-list-query-dto';
+import { PaginationQueryDto } from './../common/dto/pagination-query.dto';
 import { FindMovieDetailResponseDto } from './dto/find-movie-detail-response.dto';
 import { FindMovieListResponseDto } from './dto/find-movie-list-response.dto';
 import { MovieService } from './movie.service';
@@ -36,8 +38,9 @@ export class MovieController {
   })
   @CustomApiException(() => [InvalidPageException, ExternalApiException])
   async getNowPlayingMovies(
-    @Query('page') page?: number,
+    @Query() query: PaginationQueryDto,
   ): Promise<FindMovieListResponseDto> {
+    const { page } = query;
     return this.movieService.getNowPlayingMovies(page);
   }
 
@@ -57,8 +60,9 @@ export class MovieController {
   })
   @CustomApiException(() => [InvalidPageException, ExternalApiException])
   async getTopRatedMovies(
-    @Query('page') page?: number,
+    @Query() query: PaginationQueryDto,
   ): Promise<FindMovieListResponseDto> {
+    const { page } = query;
     return this.movieService.getTopRatedMovies(page);
   }
 
@@ -78,8 +82,9 @@ export class MovieController {
   })
   @CustomApiException(() => [InvalidPageException, ExternalApiException])
   async getPopularMovies(
-    @Query('page') page?: number,
+    @Query() query: PaginationQueryDto,
   ): Promise<FindMovieListResponseDto> {
+    const { page } = query;
     return this.movieService.getPopularMovies(page);
   }
 
@@ -110,12 +115,9 @@ export class MovieController {
     InvalidPageException,
   ])
   async getMoviesByGenre(
-    @Query('genreId', new ParseArrayPipe({ items: String, optional: true }))
-    genreId: string[],
-
-    @Query('page')
-    page?: number,
+    @Query() query: ContentListQueryDto,
   ): Promise<FindMovieListResponseDto> {
+    const { genreId, page } = query;
     return this.movieService.getMoviesByGenre(genreId, page);
   }
 
@@ -167,8 +169,9 @@ export class MovieController {
   ])
   async getRecommendedMoviesById(
     @Param('movieId') movieId: number,
-    @Query('page') page?: number,
+    @Query() query: PaginationQueryDto,
   ): Promise<FindMovieListResponseDto> {
+    const { page } = query;
     return this.movieService.getRecommendedMoviesById(movieId, page);
   }
 }

--- a/src/movie/movie.service.ts
+++ b/src/movie/movie.service.ts
@@ -1,7 +1,6 @@
 import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { ExternalApiException } from 'src/common/exceptions/external-api-exception';
 import { buildTmdbUrl, fetchFromTmdb } from '../common/utils/tmdb.utils';
 import { FindMovieDetailResponseDto } from './dto/find-movie-detail-response.dto';
 import { FindMovieListResponseDto } from './dto/find-movie-list-response.dto';
@@ -18,68 +17,64 @@ export class MovieService {
   // 영화 상세 정보 조회
   async getMovieById(id: number): Promise<FindMovieDetailResponseDto> {
     const url = buildTmdbUrl(`/movie/${id}`);
-    const tmdbResponse = await fetchFromTmdb<TMDBMovieDetailResponse>(
+    const tmdbData = await fetchFromTmdb<TMDBMovieDetailResponse>(
       this.httpService,
       url,
       this.configService,
     );
-    if (tmdbResponse.error) throw new ExternalApiException();
-
-    return FindMovieDetailResponseDto.of(tmdbResponse.data!);
+    return FindMovieDetailResponseDto.of(tmdbData);
   }
 
   // 상영 중인 영화 조회
   async getNowPlayingMovies(page = 1): Promise<FindMovieListResponseDto> {
     const url = buildTmdbUrl('/movie/now_playing', { page });
-    const tmdbResponse = await fetchFromTmdb<TMDBNowPlayingResponse>(
+    const tmdbData = await fetchFromTmdb<TMDBNowPlayingResponse>(
       this.httpService,
       url,
       this.configService,
     );
-    if (tmdbResponse.error) throw new ExternalApiException();
-    return FindMovieListResponseDto.of(tmdbResponse.data!);
+    return FindMovieListResponseDto.of(tmdbData);
   }
 
   // 평점 높은 영화 조회
   async getTopRatedMovies(page = 1): Promise<FindMovieListResponseDto> {
     const url = buildTmdbUrl('/movie/top_rated', { page });
-    const tmdbResponse = await fetchFromTmdb<TMDBNowPlayingResponse>(
+    const tmdbData = await fetchFromTmdb<TMDBNowPlayingResponse>(
       this.httpService,
       url,
       this.configService,
     );
-    if (tmdbResponse.error) throw new ExternalApiException();
-    return FindMovieListResponseDto.of(tmdbResponse.data!);
+    return FindMovieListResponseDto.of(tmdbData);
   }
 
   // 인기 있는 영화 조회
   async getPopularMovies(page = 1): Promise<FindMovieListResponseDto> {
     const url = buildTmdbUrl('/movie/popular', { page });
-    const tmdbResponse = await fetchFromTmdb<TMDBNowPlayingResponse>(
+    const tmdbData = await fetchFromTmdb<TMDBNowPlayingResponse>(
       this.httpService,
       url,
       this.configService,
     );
-    if (tmdbResponse.error) throw new ExternalApiException();
-    return FindMovieListResponseDto.of(tmdbResponse.data!);
+    return FindMovieListResponseDto.of(tmdbData);
   }
 
   // 특정 장르 영화 조회
   async getMoviesByGenre(
-    genreId: number,
+    genreId: string[],
     page = 1,
   ): Promise<FindMovieListResponseDto> {
+    const genreIds = genreId.join('|');
     const url = buildTmdbUrl('/discover/movie', {
-      with_genres: genreId,
+      with_genres: genreIds,
       page: page,
     });
-    const tmdbResponse = await fetchFromTmdb<TMDBNowPlayingResponse>(
+    const tmdbData = await fetchFromTmdb<TMDBNowPlayingResponse>(
       this.httpService,
       url,
       this.configService,
     );
-    if (tmdbResponse.error) throw new ExternalApiException();
-    return FindMovieListResponseDto.of(tmdbResponse.data!);
+
+    return FindMovieListResponseDto.of(tmdbData);
   }
 
   // 추천 영화 조회
@@ -90,12 +85,11 @@ export class MovieService {
     const url = buildTmdbUrl(`/movie/${movieId}/recommendations`, {
       page: page,
     });
-    const tmdbResponse = await fetchFromTmdb<TMDBNowPlayingResponse>(
+    const tmdbData = await fetchFromTmdb<TMDBNowPlayingResponse>(
       this.httpService,
       url,
       this.configService,
     );
-    if (tmdbResponse.error) throw new ExternalApiException();
-    return FindMovieListResponseDto.of(tmdbResponse.data!);
+    return FindMovieListResponseDto.of(tmdbData);
   }
 }

--- a/src/preference/dto/request/genre-ids.dto.ts
+++ b/src/preference/dto/request/genre-ids.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt } from 'class-validator';
+
+export class GenreIdsDto {
+  @ApiProperty({
+    description: '장르 ID 목록',
+    type: [Number],
+    example: [1, 2, 3],
+  })
+  @IsInt({ each: true })
+  @Type(() => Number)
+  genreIds: number[];
+}

--- a/src/preference/dto/request/update-preference-request.dto.ts
+++ b/src/preference/dto/request/update-preference-request.dto.ts
@@ -1,0 +1,24 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsOptional, ValidateNested } from 'class-validator';
+import { GenreIdsDto } from './genre-ids.dto';
+
+export class UpdatePreferenceRequestDto {
+  @ApiPropertyOptional({
+    description: '영화 장르 ID 목록',
+    type: () => GenreIdsDto,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => GenreIdsDto)
+  movie: GenreIdsDto;
+
+  @ApiPropertyOptional({
+    description: 'TV 시리즈 장르 ID 목록',
+    type: () => GenreIdsDto,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => GenreIdsDto)
+  tv: GenreIdsDto;
+}

--- a/src/preference/dto/response/get-preferences-response.dto.ts
+++ b/src/preference/dto/response/get-preferences-response.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PreferenceDetailDto } from './preference-detail.dto';
+
+export class GetPreferenceResponseDto {
+  @ApiProperty({
+    description: '영화 선호 장르 정보',
+    type: PreferenceDetailDto,
+  })
+  movie: PreferenceDetailDto;
+
+  @ApiProperty({
+    description: 'TV 선호 장르 정보',
+    type: PreferenceDetailDto,
+  })
+  tv: PreferenceDetailDto;
+}

--- a/src/preference/dto/response/preference-detail.dto.ts
+++ b/src/preference/dto/response/preference-detail.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { GenreDto } from 'src/genre/dto/genre.dto';
+
+export class PreferenceDetailDto {
+  @ApiProperty({
+    description: '선호 장르 목록',
+    type: [GenreDto],
+  })
+  genres: GenreDto[];
+
+  @ApiProperty({
+    description: '선호 장르 개수',
+    example: 3,
+  })
+  count: number;
+}

--- a/src/preference/exceptions/genre-not-found.exception.ts
+++ b/src/preference/exceptions/genre-not-found.exception.ts
@@ -1,0 +1,7 @@
+import { NotFoundException } from './../../common/exceptions/not-found.exception';
+
+export class GenreNotFoundException extends NotFoundException {
+  constructor() {
+    super('장르가 발견되지 않았습니다.', 'GENRE_NOT_FOUND');
+  }
+}

--- a/src/preference/preference.controller.ts
+++ b/src/preference/preference.controller.ts
@@ -1,0 +1,130 @@
+import { Body, Controller, Get, Put, Req, UseGuards } from '@nestjs/common';
+import { ApiBody, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { CustomApiException } from 'src/common/decorators/custom-api-exception.decorator';
+import { JwtAuthGuard } from './../auth/guards/jwt-auth/jwt-auth.guard';
+import { RequestWithUser } from './../auth/types/request-with-user.interface';
+import { UpdatePreferenceRequestDto } from './dto/request/update-preference-request.dto';
+import { GenreNotFoundException } from './exceptions/genre-not-found.exception';
+import { PreferenceService } from './preference.service';
+
+@ApiTags('Preferences')
+@Controller('users')
+export class PreferenceController {
+  constructor(private readonly preferenceService: PreferenceService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Put('preferences')
+  @ApiOperation({
+    summary: '회원 선호 장르 저장',
+    description: '회원이 선호하는 영화/TV 시리즈 장르 목록을 저장합니다.',
+  })
+  @ApiOkResponse({
+    description: '회원이 선호하는 장르 저장 성공',
+  })
+  @ApiBody({
+    type: UpdatePreferenceRequestDto,
+    examples: {
+      movieAndTvGenres: {
+        summary: '영화와 TV 장르 모두 설정',
+        value: {
+          movie: {
+            genreIds: [1, 2],
+          },
+          tv: {
+            genreIds: [20, 21],
+          },
+        },
+      },
+      onlyMovieGenres: {
+        summary: '영화 장르만 설정',
+        value: {
+          movie: {
+            genreIds: [1, 2],
+          },
+          tv: {
+            genreIds: [],
+          },
+        },
+      },
+    },
+  })
+  @CustomApiException(() => [GenreNotFoundException])
+  async updateUserPreferences(
+    @Req() req: RequestWithUser,
+    @Body() body: UpdatePreferenceRequestDto,
+  ) {
+    return this.preferenceService.updateUserPreferences(req.user.id, body);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('preferences')
+  @ApiOperation({
+    summary: '회원 선호 장르 전체 조회',
+    description: '회원이 선호하는 영화/TV 시리즈 전체 장르 목록을 조회합니다.',
+  })
+  @ApiOkResponse({
+    description: '회원 선호 장르 전체 조회 성공',
+    schema: {
+      example: {
+        movies: {
+          genres: [
+            { id: 1, name: '액션', emoji: '🔥' },
+            { id: 2, name: '모험', emoji: '🗺️' },
+          ],
+          count: 2,
+        },
+        tvs: {
+          genres: [{ id: 20, name: '드라마', emoji: '🎭' }],
+          count: 1,
+        },
+      },
+    },
+  })
+  async getUserPreferences(@Req() req: RequestWithUser) {
+    return this.preferenceService.getUserPreferences(req.user.id);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('preferences/movies')
+  @ApiOperation({
+    summary: '회원 영화 취향 조회',
+    description: '회원이 선호하는 영화 장르 목록을 조회합니다.',
+  })
+  @ApiOkResponse({
+    description: '회원 영화 취향 조회 성공',
+    schema: {
+      example: {
+        genres: [
+          { id: 1, name: '액션', emoji: '🔥' },
+          { id: 2, name: '모험', emoji: '🗺️' },
+        ],
+        count: 2,
+      },
+    },
+  })
+  async getMoviePreferences(@Req() req: RequestWithUser) {
+    return this.preferenceService.getMoviePreferences(req.user.id);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('preferences/tvs')
+  @ApiOperation({
+    summary: '회원 TV 시리즈 취향 조회',
+    description: '회원이 선호하는 TV 시리즈 장르 목록을 조회합니다.',
+  })
+  @ApiOkResponse({
+    description: '회원 TV 시리즈 취향 조회 성공',
+    schema: {
+      example: {
+        genres: [
+          { id: 21, name: '애니메이션', emoji: '🎨' },
+          { id: 24, name: '드라마', emoji: '🎭' },
+        ],
+        count: 2,
+      },
+    },
+  })
+  async getTvPreferences(@Req() req: RequestWithUser) {
+    return this.preferenceService.getTvPreferences(req.user.id);
+  }
+}

--- a/src/preference/preference.module.ts
+++ b/src/preference/preference.module.ts
@@ -2,12 +2,18 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Genre } from 'src/genre/entity/genre.entity';
 import { User } from 'src/user/user.entity';
+import { UserModule } from 'src/user/user.module';
+import { GenreModule } from './../genre/genre.module';
 import { PreferenceController } from './preference.controller';
 import { Preference } from './preference.entity';
 import { PreferenceService } from './preference.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Preference, User, Genre])],
+  imports: [
+    TypeOrmModule.forFeature([Preference, User, Genre]),
+    UserModule,
+    GenreModule,
+  ],
   controllers: [PreferenceController],
   providers: [PreferenceService],
 })

--- a/src/preference/preference.module.ts
+++ b/src/preference/preference.module.ts
@@ -1,4 +1,14 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Genre } from 'src/genre/entity/genre.entity';
+import { User } from 'src/user/user.entity';
+import { PreferenceController } from './preference.controller';
+import { Preference } from './preference.entity';
+import { PreferenceService } from './preference.service';
 
-@Module({})
+@Module({
+  imports: [TypeOrmModule.forFeature([Preference, User, Genre])],
+  controllers: [PreferenceController],
+  providers: [PreferenceService],
+})
 export class PreferenceModule {}

--- a/src/preference/preference.service.ts
+++ b/src/preference/preference.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
 import { ContentType } from 'src/common/types/content-type.enum';
 import { GenreDto } from 'src/genre/dto/genre.dto';
 import { Genre } from 'src/genre/entity/genre.entity';
@@ -18,7 +18,6 @@ export class PreferenceService {
     @InjectRepository(Preference)
     private readonly preferenceRepository: Repository<Preference>,
 
-    @InjectDataSource()
     private readonly dataSource: DataSource,
 
     private readonly userService: UserService,

--- a/src/preference/preference.service.ts
+++ b/src/preference/preference.service.ts
@@ -1,0 +1,115 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ContentType } from 'src/common/types/content-type.enum';
+import { GenreDto } from 'src/genre/dto/genre.dto';
+import { Genre } from 'src/genre/entity/genre.entity';
+import { User } from 'src/user/user.entity';
+import { In, Repository } from 'typeorm';
+import { UserNotFoundException } from './../user/exceptions/user-not-found.exception';
+import { UpdatePreferenceRequestDto } from './dto/request/update-preference-request.dto';
+import { GetPreferenceResponseDto } from './dto/response/get-preferences-response.dto';
+import { PreferenceDetailDto } from './dto/response/preference-detail.dto';
+import { GenreNotFoundException } from './exceptions/genre-not-found.exception';
+import { Preference } from './preference.entity';
+
+@Injectable()
+export class PreferenceService {
+  constructor(
+    @InjectRepository(Preference)
+    private readonly preferenceRepository: Repository<Preference>,
+
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+
+    @InjectRepository(Genre)
+    private readonly genreRepository: Repository<Genre>,
+  ) {}
+
+  async updateUserPreferences(
+    userId: number,
+    dto: UpdatePreferenceRequestDto,
+  ): Promise<void> {
+    const user = await this.getUserOrThrow(userId);
+    const genreIds = this.extractGenreIds(dto);
+    await this.preferenceRepository.delete({ user: { id: userId } });
+    if (genreIds.length === 0) return;
+
+    const genres = await this.getGenresOrThrow(genreIds);
+    const preferences = this.createPreferences(user, genres);
+    await this.preferenceRepository.save(preferences);
+  }
+
+  // 전체 취향 조회
+  async getUserPreferences(userId: number): Promise<GetPreferenceResponseDto> {
+    await this.getUserOrThrow(userId);
+    const preferences = await this.getPreferencesByUserId(userId);
+    return {
+      movie: this.buildPreferenceDetail(preferences, ContentType.MOVIE),
+      tv: this.buildPreferenceDetail(preferences, ContentType.TV),
+    };
+  }
+
+  // 회원 영화 취향 조회
+  async getMoviePreferences(userId: number): Promise<PreferenceDetailDto> {
+    await this.getUserOrThrow(userId);
+    const preferences = await this.getPreferencesByUserId(userId);
+    return this.buildPreferenceDetail(preferences, 0);
+  }
+
+  // 회원 TV 취향 정보 조회
+  async getTvPreferences(userId: number): Promise<PreferenceDetailDto> {
+    await this.getUserOrThrow(userId);
+    const preferences = await this.getPreferencesByUserId(userId);
+    return this.buildPreferenceDetail(preferences, 1);
+  }
+
+  // GenreId 추출
+  private extractGenreIds(dto: UpdatePreferenceRequestDto): number[] {
+    const movieGenreIds = dto.movie?.genreIds ?? [];
+    const tvGenreIds = dto.tv?.genreIds ?? [];
+    return [...movieGenreIds, ...tvGenreIds];
+  }
+
+  // User 검증
+  private async getUserOrThrow(userId: number): Promise<User> {
+    const user = await this.userRepository.findOneBy({ id: userId });
+    if (!user) throw new UserNotFoundException();
+    return user;
+  }
+
+  // Genre 존재 검증
+  private async getGenresOrThrow(genreIds: number[]): Promise<Genre[]> {
+    const genres = await this.genreRepository.findBy({ id: In(genreIds) });
+    if (genres.length !== genreIds.length) throw new GenreNotFoundException();
+    return genres;
+  }
+
+  // Preference 생성
+  private createPreferences(user: User, genres: Genre[]): Preference[] {
+    return genres.map((genre) =>
+      this.preferenceRepository.create({ user, genre }),
+    );
+  }
+
+  private async getPreferencesByUserId(userId: number): Promise<Preference[]> {
+    return this.preferenceRepository.find({
+      where: { user: { id: userId } },
+      relations: ['genre'],
+    });
+  }
+
+  // contentType 기준 분기하여 응답 DTO 생성
+  private buildPreferenceDetail(
+    preferences: Preference[],
+    contentType: ContentType,
+  ): PreferenceDetailDto {
+    const genres = preferences
+      .filter((p) => p.genre.contentType === contentType)
+      .map((p) => GenreDto.of(p.genre));
+
+    return {
+      genres,
+      count: genres.length,
+    };
+  }
+}

--- a/src/tv/dto/find-tv-detail-response.dto.ts
+++ b/src/tv/dto/find-tv-detail-response.dto.ts
@@ -11,6 +11,9 @@ export class FindTvDetailResponseDto {
   id: number;
 
   @ApiProperty()
+  contentType: string;
+
+  @ApiProperty()
   title: string;
 
   @ApiProperty()
@@ -82,6 +85,7 @@ export class FindTvDetailResponseDto {
   static of(raw: TMDBTvDetailResponse): FindTvDetailResponseDto {
     return {
       id: raw.id,
+      contentType: 'tv',
       title: raw.name,
       overview: raw.overview,
       posterPath: raw.poster_path,

--- a/src/tv/dto/find-tv-list-response.dto.ts
+++ b/src/tv/dto/find-tv-list-response.dto.ts
@@ -1,10 +1,17 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsArray, IsNumber, ValidateNested } from 'class-validator';
+import { IsArray, IsNumber, IsString, ValidateNested } from 'class-validator';
 import type { TMDBTvListResponse } from '../interfaces/tv-list.interface';
 import { TvListItemDto } from './tv-list-item.dto';
 
 export class FindTvListResponseDto {
+  @ApiProperty({
+    description: '콘텐츠 유형',
+    example: 'tv',
+  })
+  @IsString()
+  contentType: string;
+
   @ApiProperty({
     description: '조회된 TV 프로그램 목록',
     type: [TvListItemDto],
@@ -43,6 +50,7 @@ export class FindTvListResponseDto {
   // TMDB 응답 객체 -> FindTvListResponseDto 변환 메서드
   static of(raw: TMDBTvListResponse): FindTvListResponseDto {
     return {
+      contentType: 'tv',
       tvs: raw.results.map((tv) => TvListItemDto.of(tv)),
       page: raw.page,
       totalPages: raw.total_pages,

--- a/src/tv/tv.controller.ts
+++ b/src/tv/tv.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, ParseArrayPipe, Query } from '@nestjs/common';
+import { Controller, Get, Param, Query } from '@nestjs/common';
 import {
   ApiOkResponse,
   ApiOperation,
@@ -11,6 +11,8 @@ import { ContentNotFoundException } from 'src/common/exceptions/content-not-foun
 import { ExternalApiException } from 'src/common/exceptions/external-api-exception';
 import { InvalidGenreIdException } from 'src/common/exceptions/invalid-genre-id.exception';
 import { InvalidPageException } from 'src/common/exceptions/invalid-page.exception';
+import { ContentListQueryDto } from './../common/dto/content-list-query-dto';
+import { PaginationQueryDto } from './../common/dto/pagination-query.dto';
 import { FindTvDetailResponseDto } from './dto/find-tv-detail-response.dto';
 import { FindTvListResponseDto } from './dto/find-tv-list-response.dto';
 import { TvService } from './tv.service';
@@ -36,8 +38,9 @@ export class TvController {
   })
   @CustomApiException(() => [ExternalApiException, InvalidPageException])
   async getNowPlayingTv(
-    @Query('page') page?: number,
+    @Query() query: PaginationQueryDto,
   ): Promise<FindTvListResponseDto> {
+    const { page } = query;
     return this.tvService.getNowPlayingTvs(page);
   }
 
@@ -57,8 +60,9 @@ export class TvController {
   })
   @CustomApiException(() => [ExternalApiException, InvalidPageException])
   async getTopRatedTv(
-    @Query('page') page?: number,
+    @Query() query: PaginationQueryDto,
   ): Promise<FindTvListResponseDto> {
+    const { page } = query;
     return this.tvService.getTopRatedTvs(page);
   }
 
@@ -78,8 +82,9 @@ export class TvController {
   })
   @CustomApiException(() => [ExternalApiException, InvalidPageException])
   async getPopularTv(
-    @Query('page') page?: number,
+    @Query() query: PaginationQueryDto,
   ): Promise<FindTvListResponseDto> {
+    const { page } = query;
     return this.tvService.getPopularTvs(page);
   }
 
@@ -110,10 +115,9 @@ export class TvController {
     InvalidPageException,
   ])
   async getTvsByGenre(
-    @Query('genreId', new ParseArrayPipe({ items: String, optional: true }))
-    genreId: string[],
-    @Query('page') page?: number,
+    @Query() query: ContentListQueryDto,
   ): Promise<FindTvListResponseDto> {
+    const { genreId, page } = query;
     return this.tvService.getTvsByGenre(genreId, page);
   }
 
@@ -162,8 +166,9 @@ export class TvController {
   ])
   async getRecommendedTvsById(
     @Param('tvId') tvId: number,
-    @Query('page') page?: number,
+    @Query() query: PaginationQueryDto,
   ): Promise<FindTvListResponseDto> {
+    const { page } = query;
     return this.tvService.getRecommendedTvsById(tvId, page);
   }
 }

--- a/src/tv/tv.controller.ts
+++ b/src/tv/tv.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { Controller, Get, Param, ParseArrayPipe, Query } from '@nestjs/common';
 import {
   ApiOkResponse,
   ApiOperation,
@@ -110,7 +110,8 @@ export class TvController {
     InvalidPageException,
   ])
   async getTvsByGenre(
-    @Query('genreId') genreId: number,
+    @Query('genreId', new ParseArrayPipe({ items: String, optional: true }))
+    genreId: string[],
     @Query('page') page?: number,
   ): Promise<FindTvListResponseDto> {
     return this.tvService.getTvsByGenre(genreId, page);

--- a/src/tv/tv.service.ts
+++ b/src/tv/tv.service.ts
@@ -1,7 +1,6 @@
 import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { ExternalApiException } from 'src/common/exceptions/external-api-exception';
 import { buildTmdbUrl, fetchFromTmdb } from '../common/utils/tmdb.utils';
 import { FindTvDetailResponseDto } from './dto/find-tv-detail-response.dto';
 import { FindTvListResponseDto } from './dto/find-tv-list-response.dto';
@@ -18,67 +17,63 @@ export class TvService {
   // TV 시리즈 상세 정보 조회
   async getTvById(id: number): Promise<FindTvDetailResponseDto> {
     const url = buildTmdbUrl(`/tv/${id}`);
-    const tmdbResponse = await fetchFromTmdb<TMDBTvDetailResponse>(
+    const tmdbData = await fetchFromTmdb<TMDBTvDetailResponse>(
       this.httpService,
       url,
       this.configService,
     );
-    if (tmdbResponse.error) throw new ExternalApiException();
-    return FindTvDetailResponseDto.of(tmdbResponse.data!);
+    return FindTvDetailResponseDto.of(tmdbData);
   }
 
   // 상영 중인 TV 시리즈 조회
   async getNowPlayingTvs(page = 1): Promise<FindTvListResponseDto> {
     const url = buildTmdbUrl('/tv/on_the_air', { page });
-    const tmdbResponse = await fetchFromTmdb<TMDBTvListResponse>(
+    const tmdbData = await fetchFromTmdb<TMDBTvListResponse>(
       this.httpService,
       url,
       this.configService,
     );
-    if (tmdbResponse.error) throw new ExternalApiException();
-    return FindTvListResponseDto.of(tmdbResponse.data!);
+    return FindTvListResponseDto.of(tmdbData);
   }
 
   // 평점 높은 TV 시리즈 조회
   async getTopRatedTvs(page = 1): Promise<FindTvListResponseDto> {
     const url = buildTmdbUrl('/tv/top_rated', { page });
-    const tmdbResponse = await fetchFromTmdb<TMDBTvListResponse>(
+    const tmdbData = await fetchFromTmdb<TMDBTvListResponse>(
       this.httpService,
       url,
       this.configService,
     );
-    if (tmdbResponse.error) throw new ExternalApiException();
-    return FindTvListResponseDto.of(tmdbResponse.data!);
+    return FindTvListResponseDto.of(tmdbData);
   }
 
   // 인기 있는 TV 시리즈 조회
   async getPopularTvs(page = 1): Promise<FindTvListResponseDto> {
     const url = buildTmdbUrl('/tv/popular', { page });
-    const tmdbResponse = await fetchFromTmdb<TMDBTvListResponse>(
+    const tmdbData = await fetchFromTmdb<TMDBTvListResponse>(
       this.httpService,
       url,
       this.configService,
     );
-    if (tmdbResponse.error) throw new ExternalApiException();
-    return FindTvListResponseDto.of(tmdbResponse.data!);
+    return FindTvListResponseDto.of(tmdbData);
   }
 
   // 특정 장르 TV 시리즈 조회
   async getTvsByGenre(
-    genreId: number,
+    genreId: string[],
     page = 1,
   ): Promise<FindTvListResponseDto> {
+    const genreIds = genreId.join('|');
     const url = buildTmdbUrl('/discover/tv', {
-      with_genres: genreId,
+      with_genres: genreIds,
       page: page,
     });
-    const tmdbResponse = await fetchFromTmdb<TMDBTvListResponse>(
+    const tmdbData = await fetchFromTmdb<TMDBTvListResponse>(
       this.httpService,
       url,
       this.configService,
     );
-    if (tmdbResponse.error) throw new ExternalApiException();
-    return FindTvListResponseDto.of(tmdbResponse.data!);
+    return FindTvListResponseDto.of(tmdbData);
   }
 
   // 추천 TV 시리즈 조회
@@ -89,12 +84,12 @@ export class TvService {
     const url = buildTmdbUrl(`/tv/${tvId}/recommendations`, {
       page: page,
     });
-    const tmdbResponse = await fetchFromTmdb<TMDBTvListResponse>(
+    const tmdbData = await fetchFromTmdb<TMDBTvListResponse>(
       this.httpService,
       url,
       this.configService,
     );
-    if (tmdbResponse.error) throw new ExternalApiException();
-    return FindTvListResponseDto.of(tmdbResponse.data!);
+
+    return FindTvListResponseDto.of(tmdbData);
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -3,6 +3,7 @@ import { plainToInstance } from 'class-transformer';
 import { AlreadyRegisteredAccountException } from 'src/auth/exceptions/already-registered-account.exception';
 import { generateRandomNickname } from 'src/common/utils/nickname.util';
 import { UserNotFoundException } from 'src/user/exceptions/user-not-found.exception';
+import { User } from 'src/user/user.entity';
 import { CreateUserRequestDto } from './dto/request/create-user-request.dto';
 import { UpdateUserProfileRequestDto } from './dto/request/update-user-request.dto';
 import { UserResponseDto } from './dto/response/user-response.dto';
@@ -16,25 +17,15 @@ export class UserService {
   constructor(private readonly userRepository: UserRepository) {}
 
   async findUserById(id: number): Promise<UserResponseDto> {
-    const findUser = await this.userRepository.findOneById(id);
-
-    if (!findUser) {
-      throw new UserNotFoundException();
-    }
-
-    return plainToInstance(UserResponseDto, findUser, {
+    const user = await this.getOrThrowById(id);
+    return plainToInstance(UserResponseDto, user, {
       excludeExtraneousValues: true,
     });
   }
 
   async findUserByEmail(email: string): Promise<UserResponseDto> {
-    const findUser = await this.userRepository.findOneByEmail(email);
-
-    if (!findUser) {
-      throw new UserNotFoundException();
-    }
-
-    return plainToInstance(UserResponseDto, findUser, {
+    const user = await this.getOrThrowByEmail(email);
+    return plainToInstance(UserResponseDto, user, {
       excludeExtraneousValues: true,
     });
   }
@@ -94,5 +85,16 @@ export class UserService {
     const findUser = await this.userRepository.findOneByEmail(email);
     if (!findUser) return { isDuplicate: false };
     return { isDuplicate: true, provider: findUser.provider };
+  }
+
+  async getOrThrowById(id: number): Promise<User> {
+    const user = await this.userRepository.findOneById(id);
+    if (!user) throw new UserNotFoundException();
+    return user;
+  }
+  async getOrThrowByEmail(email: string): Promise<User> {
+    const user = await this.userRepository.findOneByEmail(email);
+    if (!user) throw new UserNotFoundException();
+    return user;
   }
 }


### PR DESCRIPTION
Closes #27 
## 개요

- #27 
- 선호 장르 설정/조회 기능을 위한 DTO 정의 및 Swagger 문서화, 커스텀 예외 처리 구현

## 작업사항

- **요청 DTO 정의**
  - `GenreIdsDto`: 장르 ID 배열 구조 정의 및 유효성 검사
  - `UpdatePreferenceRequestDto`: 영화/TV 시리즈 선호 장르를 함께 받는 구조
- **응답 DTO 정의**
  - `PreferenceDetailDto`: 사용자 선호 장르 목록 및 개수 응답
  - `GetPreferenceResponseDto`: 영화/TV 시리즈 선호 장르를 함께 반환하는 최상위 구조
- **커스텀 예외 처리**
  - 장르가 존재하지 않을 경우 커스텀 예외 `GenreNotFoundException` 처리

## 주의사항

- 현재 DTO 구조는 `movie`, `tv`에 한정되어 있으나, 추후 콘텐츠 유형이 확장될 경우 해당 구조 및 DTO 재설계가 필요할 수 있습니다.
