### PR TITLE
Chore: 브랜치 네이밍 규칙 확장 및 배포 브랜치 전략 적용

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,1 @@
-npx branch-naming-check "^(feat|fix|chore|refactor|release|hotfix|test|docs)/[a-z0-9-]+$"
+npx branch-naming-check "^(feat|fix|chore|refactor|release|hotfix|test|docs)/[a-z0-9-]+$|^develop$"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,1 @@
-npx branch-naming-check "^(feat|fix|chore|refactor)/[a-z0-9-]+$"
+npx branch-naming-check "^(feat|fix|chore|refactor|release|hotfix|test|docs)/[a-z0-9-]+$"


### PR DESCRIPTION
Closes #37 

## 개요

- 브랜치 네이밍 규칙을 Git Flow 전략에 맞게 확장하고, develop 브랜치 기반의 배포 전략을 도입합니다.
- 기존 규칙에 release, hotfix, test, docs, develop 브랜치 유형을 추가했습니다.
- CI/CD 워크플로의 기준 브랜치를 develop로 할 예정입니다.
- 운영(main)과 개발/테스트(develop) 환경을 분리할 예정입니다.

## 작업사항

- .husky/pre-push 내 branch-naming-check 정규식 확장

## 주의사항

- develop 브랜치에 push 시 자동으로 개발/테스트 서버에 배포되도록 적용할 예정입니다.
- 이후에 develop 브랜치를 만들 예정이고, 앞으로는 develop에 Merge하는 것으로 하면 좋을 것 같습니다.
- 운영 배포는 develop에서 모든 작업이 끝난 후, main 브랜치에 머지 후 별도 워크플로를 통해 진행될 예정입니다. (프로젝트가 끝나갈 쯤에 워크플로 연결 예정)