### PR TITLE
Feat: SSM 기반 EC2 배포 전환 및 워크플로우 개선

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,28 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Get EC2 Instance ID
+        id: get_instance_id
+        run: |
+          INSTANCE_ID=$(aws ec2 describe-instances \
+            --filters "Name=tag:Name,Values=TasteBox-Server" "Name=instance-state-name,Values=running" \
+            --query "Reservations[0].Instances[0].InstanceId" \
+            --output text)
+          if [ "$INSTANCE_ID" == "None" ] || [ -z "$INSTANCE_ID" ]; then
+            echo "Error: Could not find running EC2 instance with Name tag 'TasteBox-Server'."
+            exit 1
+          fi
+          echo "Found EC2 Instance ID: $INSTANCE_ID"
+          echo "instance_id=$INSTANCE_ID" >> $GITHUB_OUTPUT
 
       - name: Create .env file from secrets
         run: |
@@ -38,22 +59,41 @@ jobs:
           echo "S3_BUCKET=${{ secrets.S3_BUCKET }}" >> .env
           echo "AWS_REGION=${{ secrets.AWS_REGION }}" >> .env
 
-      - name: Copy project files to EC2
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          source: "."
-          target: "/home/ubuntu/TasteBox-Backend"
+      - name: Create application artifact from Git history
+        run: |
+          git archive --format=tar --output app.tar HEAD
+          gzip app.tar
+          echo "Created app.tar.gz from git archive."
 
-      - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1.0.0
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script: |
-            cd /home/ubuntu/TasteBox-Backend
-            docker compose down || true
-            docker compose up -d --build
+      - name: Upload artifacts to S3
+        run: |
+          aws s3 cp app.tar.gz s3://s3-tastebox/app.tar.gz
+          aws s3 cp .env s3://s3-tastebox/.env
+
+      - name: Deploy via SSM Run Command
+        run: |
+          aws ssm send-command \
+            --instance-ids ${{ steps.get_instance_id.outputs.instance_id }} \
+            --document-name "AWS-RunShellScript" \
+            --comment "Deploy TasteBox backend application with Docker Compose" \
+            --parameters 'commands=[
+              "sudo su - ubuntu",
+              "cd /home/ubuntu",
+              "aws s3 cp s3://s3-tastebox/app.tar.gz .",
+              "aws s3 cp s3://s3-tastebox/.env .",
+              "mkdir -p TasteBox-Backend",
+              "rm -rf TasteBox-Backend/*",
+              "tar -xzf app.tar.gz -C TasteBox-Backend",
+              "mv .env TasteBox-Backend/.env",
+              "rm app.tar.gz",
+
+              "cd TasteBox-Backend",
+              "sudo docker compose down || true",
+              "sudo docker compose up -d --build",
+              "sudo docker system prune -f"
+            ]'
+
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ap-northeast-2

--- a/infra/ec2-user-data/init.sh
+++ b/infra/ec2-user-data/init.sh
@@ -16,25 +16,20 @@ apt-get install -y nodejs
 curl -fsSL https://get.docker.com -o get-docker.sh
 sh get-docker.sh
 
-# 5. Install Docker Compose plugin
-DOCKER_COMPOSE_VERSION=$(curl -s https://api.github.com/repos/docker/compose/releases/latest | grep tag_name | cut -d '"' -f 4)
-curl -SL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-chmod +x /usr/local/bin/docker-compose
-
 systemctl enable docker
 systemctl start docker
 
-# 6. Install AWS CLI
+# 5. Install AWS CLI
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 unzip awscliv2.zip
 ./aws/install
 rm -rf awscliv2.zip aws/
 aws --version || true  # Check installation, ignore failure
 
-# 7. Install nginx and basic setup
+# 6. Install nginx and basic setup
 apt-get install -y nginx
 
-# 8. Remove default nginx config and set up reverse proxy
+# 7. Remove default nginx config and set up reverse proxy
 rm -f /etc/nginx/sites-enabled/default
 
 cat <<EOF > /etc/nginx/sites-available/tastebox
@@ -56,8 +51,8 @@ ln -sf /etc/nginx/sites-available/tastebox /etc/nginx/sites-enabled/tastebox
 
 nginx -t && systemctl restart nginx
 
-# 9. Install Certbot and issue SSL certificate (APT version, more stable for cloud-init)
+# 8. Install Certbot and issue SSL certificate (APT version, more stable for cloud-init)
 apt-get install -y certbot python3-certbot-nginx
 
-# 10. Add ubuntu user to docker group
+# 9. Add ubuntu user to docker group
 usermod -aG docker ubuntu


### PR DESCRIPTION
Closes #42 

## 개요

- SSM Run Command를 활용해 EC2 인스턴스에 artifact를 배포하는 방식으로 워크플로를 개선하였습니다.
- 기존 SSH/SCP 방식에서 발생할 수 있었던 보안 취약점과 불필요한 AWS 과금(특히 NAT Gateway 및 Elastic IP 관련) 문제를 해결했습니다.

## 작업사항

- 배포 방식 전환 (SSH/SCP -> S3/SSM)
  - 기존의 SSH/SCP 방식은 GitHub Actions 러너의 유동적인 IP 문제로 인해 EC2 인스턴스의 SSH 포트(22번)를 넓게 개방해야 하는 보안 위험이 있었습니다.
  - 이를 해결하기 위해, GitHub Actions 워크플로우에서 생성된 배포 artifact 및 .env 파일을 S3 버킷에 업로드하고, EC2 인스턴스에서는 AWS Systems Manager (SSM) Run Command를 통해 S3로부터 해당 파일들을 다운로드하여 배포하도록 변경했습니다.

## 주의사항

- EC2 인스턴스에 SSM Agent가 설치되어 있어야 하며, 관련 IAM Role이 올바르게 부여되어 있어야 합니다. (추후 문서 작성 예정)
- S3 버킷 및 SSM 명령 실행 권한 등 AWS 리소스 설정을 반드시 확인해야 합니다.
- .env 파일에 필요한 모든 환경 변수가 GitHub Secrets에 정확히 설정되어 있어야 합니다.