### PR TITLE
Feat: Validation 에러 응답 일관화 및 Swagger 문서화 개선

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -11,6 +11,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import {
+  ApiBadRequestResponse,
   ApiBearerAuth,
   ApiBody,
   ApiCreatedResponse,
@@ -23,6 +24,9 @@ import { Response } from 'express';
 
 import * as ms from 'ms';
 import { CustomApiException } from 'src/common/decorators/custom-api-exception.decorator';
+import { loginValidationErrorSchema } from 'src/common/swagger/login-validation-error-schema';
+import { passwordValidationErrorSchema } from 'src/common/swagger/password-validation-error-schema';
+import { signupValidationErrorSchema } from 'src/common/swagger/signup-validation-error-schema';
 import { setTokenCookie } from 'src/common/utils/cookie.util';
 import { CreateUserRequestDto } from 'src/user/dto/request/create-user-request.dto';
 import { UniqueNicknameGenerationException } from 'src/user/exceptions/unique-nickname-generation.exception';
@@ -60,6 +64,7 @@ export class AuthController {
   @ApiCreatedResponse({
     description: '회원가입 성공',
   })
+  @ApiBadRequestResponse({ schema: signupValidationErrorSchema })
   @CustomApiException(() => [
     DuplicateNicknameException,
     AlreadyRegisteredAccountException,
@@ -77,6 +82,7 @@ export class AuthController {
     description:
       '로그인 성공 시 accessToken과 refreshToken이 쿠키에 저장되어 반환됩니다.',
   })
+  @ApiBadRequestResponse({ schema: loginValidationErrorSchema })
   @CustomApiException(() => [
     InvalidCredentialsException,
     OAuthAccountLoginException,
@@ -134,6 +140,7 @@ export class AuthController {
   @ApiOkResponse({
     description: '비밀번호가 성공적으로 변경되었습니다.',
   })
+  @ApiBadRequestResponse({ schema: passwordValidationErrorSchema })
   @CustomApiException(() => [
     UserNotFoundException,
     OAuthAccountPasswordChangeException,

--- a/src/auth/dto/request/login-request.dto.ts
+++ b/src/auth/dto/request/login-request.dto.ts
@@ -4,12 +4,12 @@ import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
 // login.dto.ts
 export class LoginRequestDto {
   @ApiProperty({ description: '이메일', example: 'stepup@mail.com' })
-  @IsNotEmpty()
-  @IsEmail()
+  @IsNotEmpty({ message: '이메일을 입력해주세요.' })
+  @IsEmail({}, { message: '이메일 형식이 올바르지 않습니다.' })
   email: string;
 
   @ApiProperty({ description: '비밀번호', example: '1234qwer' })
-  @IsNotEmpty()
+  @IsNotEmpty({ message: '비밀번호를 입력해주세요.' })
   @IsString()
   password: string;
 }

--- a/src/auth/dto/request/update-password-request.dto.ts
+++ b/src/auth/dto/request/update-password-request.dto.ts
@@ -3,10 +3,10 @@ import { IsNotEmpty, IsString } from 'class-validator';
 
 export class UpdatePasswordRequestDto {
   @ApiProperty({
-    description: '현재 비밀번호',
+    description: '기존 비밀번호',
     example: 'currentPassword123!',
   })
-  @IsNotEmpty()
+  @IsNotEmpty({ message: '기존 비밀번호를 입력해주세요.' })
   @IsString()
   currentPassword: string;
 
@@ -14,7 +14,7 @@ export class UpdatePasswordRequestDto {
     description: '새 비밀번호',
     example: 'newPassword456!',
   })
-  @IsNotEmpty()
+  @IsNotEmpty({ message: '새 비밀번호를 입력해주세요.' })
   @IsString()
   newPassword: string;
 
@@ -22,7 +22,7 @@ export class UpdatePasswordRequestDto {
     description: '새 비밀번호 확인',
     example: 'newPassword456!',
   })
-  @IsNotEmpty()
+  @IsNotEmpty({ message: '새 비밀번호 확인을 입력해주세요.' })
   @IsString()
   newPasswordConfirm: string;
 }

--- a/src/common/exceptions/bad-request.exception.ts
+++ b/src/common/exceptions/bad-request.exception.ts
@@ -2,7 +2,7 @@ import { HttpStatus } from '@nestjs/common';
 import { BaseException } from './base.exception';
 
 export class BadRequestException extends BaseException {
-  constructor(message: string, error: string) {
+  constructor(message: string | Record<string, string[]>, error: string) {
     super(message, error, HttpStatus.BAD_REQUEST);
   }
 }

--- a/src/common/exceptions/base.exception.ts
+++ b/src/common/exceptions/base.exception.ts
@@ -3,7 +3,11 @@ import { HttpException, type HttpStatus } from '@nestjs/common';
 export class BaseException extends HttpException {
   public readonly error: string;
 
-  constructor(message: string, error: string, status: HttpStatus) {
+  constructor(
+    message: string | Record<string, string[]>,
+    error: string,
+    status: HttpStatus,
+  ) {
     super({ message, error }, status);
     this.error = error;
   }

--- a/src/common/exceptions/validation.exception.ts
+++ b/src/common/exceptions/validation.exception.ts
@@ -1,0 +1,7 @@
+import { BadRequestException } from './bad-request.exception';
+
+export class ValidationException extends BadRequestException {
+  constructor(messages: Record<string, string[]>) {
+    super(messages, 'VALIDATION_ERROR');
+  }
+}

--- a/src/common/swagger/login-validation-error-schema.ts
+++ b/src/common/swagger/login-validation-error-schema.ts
@@ -1,0 +1,15 @@
+export const loginValidationErrorSchema = {
+  type: 'object',
+  properties: {
+    statusCode: { type: 'number', example: 400 },
+    message: {
+      type: 'object',
+      example: {
+        email: ['이메일을 입력해주세요.', '이메일 형식이 올바르지 않습니다.'],
+        password: ['비밀번호를 입력해주세요.'],
+      },
+    },
+    error: { type: 'string', example: 'VALIDATION_ERROR' },
+    timestamp: { type: 'string', example: '2025-07-04T03:44:00.000Z' },
+  },
+};

--- a/src/common/swagger/password-validation-error-schema.ts
+++ b/src/common/swagger/password-validation-error-schema.ts
@@ -1,0 +1,27 @@
+export const passwordValidationErrorSchema = {
+  type: 'object',
+  properties: {
+    statusCode: { type: 'number', example: 400 },
+    message: {
+      type: 'object',
+      example: {
+        currentPassword: [
+          '기존 비밀번호를 입력해주세요.',
+          '기존 비밀번호는 문자열이어야 합니다.',
+        ],
+        newPassword: [
+          '새 비밀번호를 입력해주세요.',
+          '새 비밀번호는 문자열이어야 합니다.',
+          '새 비밀번호는 6~20자 사이여야 하며, 공백 없이 영문, 숫자, 특수문자만 사용할 수 있어요.',
+        ],
+        newPasswordConfirm: [
+          '새 비밀번호 확인을 입력해주세요.',
+          '새 비밀번호 확인은 문자열이어야 합니다.',
+          '새 비밀번호와 새 비밀번호 확인이 일치하지 않습니다.',
+        ],
+      },
+    },
+    error: { type: 'string', example: 'VALIDATION_ERROR' },
+    timestamp: { type: 'string', example: '2025-07-04T03:44:00.000Z' },
+  },
+};

--- a/src/common/swagger/signup-validation-error-schema.ts
+++ b/src/common/swagger/signup-validation-error-schema.ts
@@ -1,0 +1,24 @@
+export const signupValidationErrorSchema = {
+  type: 'object',
+  properties: {
+    statusCode: { type: 'number', example: 400 },
+    message: {
+      type: 'object',
+      example: {
+        email: ['이메일을 입력해주세요.', '이메일 형식이 올바르지 않습니다.'],
+        password: ['비밀번호를 입력해주세요.'],
+        nickname: [
+          '닉네임을 입력해주세요.',
+          '닉네임은 2~10자 사이로 입력해주세요.',
+        ],
+        contact: [
+          '휴대폰 번호를 입력해주세요.',
+          '휴대폰 번호는 숫자만 9~11자리로 입력해주세요.',
+        ],
+        provider: ['가입 경로가 올바르지 않습니다.'],
+      },
+    },
+    error: { type: 'string', example: 'VALIDATION_ERROR' },
+    timestamp: { type: 'string', example: '2025-07-04T03:44:00.000Z' },
+  },
+};

--- a/src/common/swagger/update-user-profile-validation-error-schema.ts
+++ b/src/common/swagger/update-user-profile-validation-error-schema.ts
@@ -1,0 +1,18 @@
+export const updateUserProfileValidationErrorSchema = {
+  type: 'object',
+  properties: {
+    statusCode: { type: 'number', example: 400 },
+    message: {
+      type: 'object',
+      example: {
+        nickname: [
+          '닉네임을 입력해주세요.',
+          '닉네임은 2~10자 사이로 입력해주세요.',
+        ],
+        contact: ['휴대폰 번호는 숫자만 9~11자리로 입력해주세요.'],
+      },
+    },
+    error: { type: 'string', example: 'VALIDATION_ERROR' },
+    timestamp: { type: 'string', example: '2025-07-04T03:44:00.000Z' },
+  },
+};

--- a/src/common/utils/build-validation-error.util.ts
+++ b/src/common/utils/build-validation-error.util.ts
@@ -1,0 +1,25 @@
+import { ValidationError } from 'class-validator';
+
+export function buildValidationError(
+  errors: ValidationError[],
+): Record<string, string[]> {
+  const result: Record<string, string[]> = {};
+
+  function traverse(errors: ValidationError[], path: string[] = []) {
+    errors.forEach((error) => {
+      const currentPath = [...path, error.property];
+      if (error.constraints) {
+        const key = currentPath.join('.');
+        const constraints = error.constraints;
+        const constraintKeys = Object.keys(constraints).reverse();
+        result[key] = constraintKeys.map((k) => constraints[k]);
+      }
+      if (error.children && error.children.length > 0) {
+        traverse(error.children, currentPath);
+      }
+    });
+  }
+
+  traverse(errors);
+  return result;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,8 @@ import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import * as cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
+import { ValidationException } from './common/exceptions/validation.exception';
+import { buildValidationError } from './common/utils/build-validation-error.util';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -13,6 +15,10 @@ async function bootstrap() {
       whitelist: true,
       forbidNonWhitelisted: true,
       transform: true,
+      exceptionFactory: (errors) => {
+        const messages = buildValidationError(errors);
+        return new ValidationException(messages);
+      },
     }),
   );
 

--- a/src/user/dto/request/create-user-request.dto.ts
+++ b/src/user/dto/request/create-user-request.dto.ts
@@ -1,25 +1,41 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsEnum, IsNotEmpty, IsString } from 'class-validator';
+import {
+  IsEmail,
+  IsEnum,
+  IsNotEmpty,
+  IsString,
+  Length,
+  Matches,
+} from 'class-validator';
 import { AuthProvider } from 'src/user/enums/auth-provider.enum';
 
 export class CreateUserRequestDto {
   @ApiProperty({ description: '이메일', example: 'stepup@mail.com' })
-  @IsNotEmpty()
-  @IsEmail()
+  @IsNotEmpty({ message: '이메일을 입력해주세요.' })
+  @IsEmail({}, { message: '유효한 이메일 주소를 입력해주세요.' })
   email: string;
 
   @ApiProperty({ description: '비밀번호', example: '1234qwer' })
-  @IsNotEmpty()
+  @IsNotEmpty({ message: '비밀번호를 입력해주세요.' })
   @IsString()
+  @Matches(/^[A-Za-z\d!@#$%^&*()\-=+[\]{};:'",.<>/?\\|`~]{6,20}$/, {
+    message:
+      '비밀번호는 6~20자 사이여야 하며, 공백 없이 영문, 숫자, 특수문자만 사용할 수 있어요.',
+  })
   password: string;
 
   @ApiProperty({ description: '닉네임', example: '쌈뽕한닉네임' })
-  @IsNotEmpty()
+  @IsNotEmpty({ message: '닉네임을 입력해주세요.' })
   @IsString()
+  @Length(2, 10, { message: '닉네임은 2~10자 사이로 입력해주세요.' })
   nickname: string;
 
   @ApiProperty({ description: '연락처', example: '010-1234-5678' })
+  @IsNotEmpty({ message: '휴대폰 번호를 입력해주세요.' })
   @IsString()
+  @Matches(/^01[016789]\d{7,8}$/, {
+    message: '휴대폰 번호는 숫자만 9~11자리로 입력해주세요.',
+  })
   contact?: string;
 
   @ApiProperty({
@@ -35,6 +51,6 @@ export class CreateUserRequestDto {
     enum: AuthProvider,
     example: AuthProvider.LOCAL,
   })
-  @IsEnum(AuthProvider)
+  @IsEnum(AuthProvider, { message: '가입 경로가 올바르지 않습니다.' })
   provider?: AuthProvider;
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, Get, Patch, Req, UseGuards } from '@nestjs/common';
 import {
+  ApiBadRequestResponse,
   ApiBearerAuth,
   ApiBody,
   ApiOkResponse,
@@ -8,6 +9,7 @@ import {
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth/jwt-auth.guard';
 import { CustomApiException } from 'src/common/decorators/custom-api-exception.decorator';
+import { updateUserProfileValidationErrorSchema } from 'src/common/swagger/update-user-profile-validation-error-schema';
 import { UserNotFoundException } from 'src/user/exceptions/user-not-found.exception';
 import { RequestWithUser } from '../auth/types/request-with-user.interface';
 import { UpdateUserProfileRequestDto } from './dto/request/update-user-request.dto';
@@ -40,6 +42,7 @@ export class UserController {
   @ApiOkResponse({
     description: '회원 프로필 수정 성공',
   })
+  @ApiBadRequestResponse({ schema: updateUserProfileValidationErrorSchema })
   @CustomApiException(() => [DuplicateNicknameException])
   async updateUserProfile(
     @Req() req: RequestWithUser,


### PR DESCRIPTION
Closes #44 

## 개요

- Validation 에러 응답 구조를 표준화하고, Swagger 문서화까지 개선하였습니다.

## 작업사항

- BaseException에 변경점이 있습니다.
  - message 타입을 string | Record<string, string[]>로 확장했습니다.
  - ValidationException이 필드별 메시지 객체를 지원하도록 변경했습니다.

- buildValidationError 유틸 함수를 구현했습니다.
  - ValidationError 배열을 필드별 메시지 객체로 변환합니다.
  - 데코레이터 선언 순서대로 메시지 배열을 반환합니다.

- 글로벌 ValidationPipe에 위 내용을 적용했습니다.
  - 모든 validation 에러 응답이 일관된 구조와 메시지 순서로 반환됩니다.

- Request DTO에 변경점이 있습니다.
  - validation 데코레이터에 한글 메시지를 추가했습니다.
  - 검증로직을 추가했습니다. (정규표현식)

- Swagger 문서를 업데이트했습니다.
  - 회원가입, 로그인, 비밀번호 변경, 프로필 수정에 대한 validation 에러 스키마를 생성했습니다.
  - 각 스키마는 및 대응되는 각 엔드포인트에 @ApiBadRequestResponse로 적용했습니다.

## 주의사항

- 향후 Validation 적용하는 부분이 생기면, 이번 작업과 같은 패턴으로 진행하면 될 것 같습니다.
  - DTO 추가 및 데코레이터 추가
  - 에러 스키마 작성 및 엔드포인트에 적용