### PR TITLE
Feat: 스케줄러 동기화 날짜 추적용 엔티티 추가

### DIFF
--- a/src/content/entities/sync-status.entity.ts
+++ b/src/content/entities/sync-status.entity.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+
+@Entity()
+export class SyncStatus {
+  @PrimaryColumn({ type: 'varchar', length: 50 })
+  key: string;
+
+  @Column({ type: 'varchar', length: 100 })
+  value: string;
+}


### PR DESCRIPTION
Closes #50 

## 개요

- 마지막 동기화 날짜(`lastMetadataSyncDate`)를 메모리에 변수로 저장하면, 서버가 재시작될 때마다 이 값이 초기화됩니다.
- 이로 인해 이미 처리된 날짜의 데이터를 중복으로 동기화하거나, 특정 날짜를 건너뛰는 문제가 발생할 수 있었습니다.
- 이 문제를 해결하기 위해, 동기화 관련 상태를 키-값 형태로 영속적으로 저장하는 `SyncStatus` 엔티티를 스케줄링 서버에 추가했습니다.

## 작업사항

- `SyncStatus` 엔티티 추가

## 주의사항

- API 서버에서 직접 쓰는 엔티티는 아닙니다. API 서버의 엔티티들을 기준으로 스키마를 생성하도록 하기 위해 API 서버에도 엔티티를 배치했습니다.
