### PR TITLE
Fix: 컬렉션 생성 및 업데이트시 썸네일 업로드 관련 버그 수정

### DIFF
--- a/src/collection/collection.controller.ts
+++ b/src/collection/collection.controller.ts
@@ -71,6 +71,7 @@ export class CollectionController {
         validators: [
           new FileTypeValidator({ fileType: /(jpg|jpeg|png|webp)$/ }),
         ],
+        fileIsRequired: false,
       }),
     )
     thumbnail?: Express.Multer.File,
@@ -178,6 +179,7 @@ export class CollectionController {
         validators: [
           new FileTypeValidator({ fileType: /(jpg|jpeg|png|webp)$/ }),
         ],
+        fileIsRequired: false,
       }),
     )
     thumbnail?: Express.Multer.File,

--- a/src/collection/collection.service.ts
+++ b/src/collection/collection.service.ts
@@ -132,6 +132,7 @@ export class CollectionService {
       collectionId,
       { relations: ['user'] },
     );
+
     if (!collection) throw new CollectionNotFoundException();
     if (collection.user.id !== userId) throw new ForbiddenException();
 
@@ -161,10 +162,12 @@ export class CollectionService {
       newThumbnailUrl,
     );
 
-    if (result.affected && oldThumbnailUrl !== newThumbnailUrl) {
-      await this.deleteThumbnailIfCustom(oldThumbnailUrl);
-    } else {
+    if (result.affected === 0) {
       throw new CollectionNotFoundException();
+    }
+
+    if (oldThumbnailUrl !== newThumbnailUrl) {
+      await this.deleteThumbnailIfCustom(oldThumbnailUrl);
     }
   }
 


### PR DESCRIPTION
Closes #63 

## 개요

- 파일 입력 없이도 컬렉션 생성 및 업데이트가 가능하도록 수정했습니다.

## 작업사항

- File Validation Pipe에 누락됐던 `fileIsRequired: false` 옵션 추가
- 업데이트 시 정상흐름에서도 예외를 터뜨리던 조건문을 재구성 