### PR TITLE
Fix: Collection 생성에 대한 Response를 API 명세에 맞춤

### DIFF
--- a/src/collection/collection.controller.ts
+++ b/src/collection/collection.controller.ts
@@ -40,6 +40,8 @@ import { CreateCollectionRequestDto } from './dto/request/create-collection-requ
 import { UpdateCollectionRequestDto } from './dto/request/update-collection-request.dto';
 import { CollectionDetailResponseDto } from './dto/response/collection-detail-response.dto';
 import { CollectionListResponseDto } from './dto/response/collection-list-response.dto';
+import { CreateCollectionResponseDto } from './dto/response/create-collection.response.dto';
+import { CollectionCreateFailException } from './exception/collection-create-fail.exception';
 import { CollectionDeleteFailException } from './exception/collection-delete-fail.exception';
 import { CollectionNotFoundException } from './exception/collection-not-found.exception';
 
@@ -58,8 +60,15 @@ export class CollectionController {
     description: '생성할 컬렉션 정보 및 썸네일 파일',
     type: CreateCollectionRequestDto,
   })
-  @ApiCreatedResponse({ description: '컬렉션 생성 성공' })
-  @CustomApiException(() => [UserNotFoundException, S3UploadFailException])
+  @ApiCreatedResponse({
+    description: '컬렉션 생성 성공',
+    type: CreateCollectionResponseDto,
+  })
+  @CustomApiException(() => [
+    UserNotFoundException,
+    S3UploadFailException,
+    CollectionCreateFailException,
+  ])
   @UseGuards(JwtAuthGuard)
   @Post()
   @UseInterceptors(FileInterceptor('thumbnail'))
@@ -77,7 +86,11 @@ export class CollectionController {
     thumbnail?: Express.Multer.File,
   ) {
     const userId = req.user.id;
-    await this.collectionService.createCollection(userId, dto, thumbnail);
+    return await this.collectionService.createCollection(
+      userId,
+      dto,
+      thumbnail,
+    );
   }
 
   @ApiBearerAuth()

--- a/src/collection/collection.service.ts
+++ b/src/collection/collection.service.ts
@@ -15,6 +15,8 @@ import { UpdateCollectionRequestDto } from './dto/request/update-collection-requ
 import { CollectionDetailResponseDto } from './dto/response/collection-detail-response.dto';
 import { CollectionListResponseDto } from './dto/response/collection-list-response.dto';
 import { CollectionSummaryDto } from './dto/response/collection-summary.dto';
+import { CreateCollectionResponseDto } from './dto/response/create-collection.response.dto';
+import { CollectionCreateFailException } from './exception/collection-create-fail.exception';
 import { CollectionDeleteFailException } from './exception/collection-delete-fail.exception';
 import { CollectionNotFoundException } from './exception/collection-not-found.exception';
 
@@ -56,7 +58,17 @@ export class CollectionService {
         })
       : this.getRandomDefaultThumbnailUrl();
 
-    return this.collectionRepository.create(userId, dto, thumbnailUrl);
+    const newCollection = await this.collectionRepository.create(
+      userId,
+      dto,
+      thumbnailUrl,
+    );
+
+    if (!newCollection) {
+      throw new CollectionCreateFailException();
+    }
+
+    return new CreateCollectionResponseDto(newCollection.id);
   }
 
   async getCollections(

--- a/src/collection/dto/response/create-collection.response.dto.ts
+++ b/src/collection/dto/response/create-collection.response.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateCollectionResponseDto {
+  @ApiProperty({
+    description: '생성된 컬렉션의 고유 식별자',
+    example: 2,
+  })
+  id: number;
+
+  constructor(id: number) {
+    this.id = id;
+  }
+}

--- a/src/collection/exception/collection-create-fail.exception.ts
+++ b/src/collection/exception/collection-create-fail.exception.ts
@@ -1,0 +1,7 @@
+import { InternalServerErrorException } from 'src/common/exceptions/internal-server-error.exception';
+
+export class CollectionCreateFailException extends InternalServerErrorException {
+  constructor() {
+    super('컬렉션 생성에 실패했습니다.', 'COLLECTION_CREATE_FAIL');
+  }
+}


### PR DESCRIPTION
## 개요

- 컬렉션 생성 Response로 컬렉션 ID가 주어지지 않던 것을 수정했습니다.

## 작업사항

- 이제 Response로 컬렉션 ID를 줍니다.
