### PR TITLE
장르 배열 쿼리 파라미터 genreIds에서 genreId로 수정

### DIFF
--- a/src/content/dto/genre-pagination-query.dto.ts
+++ b/src/content/dto/genre-pagination-query.dto.ts
@@ -23,5 +23,5 @@ export class GenrePaginationQueryDto extends PaginationQueryDto {
     }
     return value;
   })
-  genreIds: number[];
+  genreId: number[];
 }

--- a/src/content/movie/movie.controller.ts
+++ b/src/content/movie/movie.controller.ts
@@ -143,8 +143,8 @@ export class MovieController {
   async getMoviesByGenreIds(
     @Query() query: GenrePaginationQueryDto,
   ): Promise<MovieListResponseDto> {
-    const { genreIds, page, limit } = query;
-    return this.movieService.getMoviesByGenreIds(genreIds, page, limit);
+    const { genreId, page, limit } = query;
+    return this.movieService.getMoviesByGenreIds(genreId, page, limit);
   }
 
   @Get(':movieId')

--- a/src/content/tv-series/tv-series.controller.ts
+++ b/src/content/tv-series/tv-series.controller.ts
@@ -138,8 +138,8 @@ export class TvSeriesController {
   async getTvsByGenre(
     @Query() query: GenrePaginationQueryDto,
   ): Promise<TvSeriesListResponseDto> {
-    const { genreIds, page, limit } = query;
-    return this.tvService.getTvSeriesByGenreIds(genreIds, page, limit);
+    const { genreId, page, limit } = query;
+    return this.tvService.getTvSeriesByGenreIds(genreId, page, limit);
   }
 
   @Get(':tvId')


### PR DESCRIPTION
## 개요

- 쿼리 파라미터 네이밍 수정

## 작업사항

- 장르별 컨텐츠 조회 요청 내 쿼리 파라미터 이름을 `genreIds` => `genreId` 로 수정