### PR TITLE
컨텐츠 장르 조회 엔드포인트 인증 제거 및 문서 최신화

### DIFF
--- a/src/genre/genre.controller.ts
+++ b/src/genre/genre.controller.ts
@@ -1,24 +1,14 @@
-// genre.controller.ts
-
-import { Controller, Get, UseGuards } from '@nestjs/common';
-import {
-  ApiBearerAuth,
-  ApiOkResponse,
-  ApiOperation,
-  ApiTags,
-} from '@nestjs/swagger';
+import { Controller, Get } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CustomApiException } from 'src/common/decorators/custom-api-exception.decorator';
+import { ContentType } from 'src/common/enums/content-type.enum';
 import { ContentNotFoundException } from 'src/common/exceptions/content-not-found.exception';
 import { ExternalApiException } from 'src/common/exceptions/external-api-exception';
-import { JwtAuthGuard } from '../auth/guards/jwt-auth/jwt-auth.guard';
-import { ContentType } from '../common/enums/content-type.enum';
 import { GenreListResponseDto } from './dto/genre-list-response.dto';
 import { GenreService } from './genre.service';
 
 @ApiTags('Genres')
-@ApiBearerAuth()
 @Controller('genres')
-@UseGuards(JwtAuthGuard)
 export class GenreController {
   constructor(private readonly genreService: GenreService) {}
 


### PR DESCRIPTION
## 개요

- 컨텐츠 장르 조회 시 인증 요구하지 않도록 수정

## 작업사항

- `@UserGuard()` 데코레이터 제거
- `@ApiBearerAuth()` 데코레이터 제거
