### PR TITLE
Fix: 이미지에 접근 권한이 없던 현상 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.842.0",
+        "@aws-sdk/s3-request-presigner": "^3.844.0",
         "@nanogiants/nestjs-swagger-api-exception-decorator": "^1.7.2",
         "@nestjs/axios": "^4.0.0",
         "@nestjs/cache-manager": "^3.0.1",
@@ -943,6 +944,25 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.844.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.844.0.tgz",
+      "integrity": "sha512-i953TKW1rXbd9G2xEgWoJZDoF0Z1ONRlrXkOKDGOrY/uQhAIPNDz5k6tFcXG5oIaLWW197ShENv3CeEJnhfh3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "3.844.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-format-url": "3.840.0",
+        "@smithy/middleware-endpoint": "^4.1.14",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.6",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.844.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.844.0.tgz",
@@ -1013,6 +1033,21 @@
         "@smithy/types": "^4.3.1",
         "@smithy/url-parser": "^4.0.4",
         "@smithy/util-endpoints": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.840.0.tgz",
+      "integrity": "sha512-VB1PWyI1TQPiPvg4w7tgUGGQER1xxXPNUqfh3baxUSFi1Oh8wHrDnFywkxLm3NMmgDmnLnSZ5Q326qAoyqKLSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/querystring-builder": "^4.0.4",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.842.0",
+    "@aws-sdk/s3-request-presigner": "^3.844.0",
     "@nanogiants/nestjs-swagger-api-exception-decorator": "^1.7.2",
     "@nestjs/axios": "^4.0.0",
     "@nestjs/cache-manager": "^3.0.1",

--- a/src/collection/entities/collection.entity.ts
+++ b/src/collection/entities/collection.entity.ts
@@ -26,7 +26,7 @@ export class Collection extends BaseEntity {
   collectionContents: CollectionContent[];
 
   @Column({ type: 'varchar' })
-  thumbnail: string; // URL
+  thumbnail: string; // 키
 
   @Column({ type: 'boolean', default: true })
   isPublic: boolean;

--- a/src/common/aws/s3.service.ts
+++ b/src/common/aws/s3.service.ts
@@ -1,8 +1,10 @@
 import {
   DeleteObjectCommand,
+  GetObjectCommand,
   PutObjectCommand,
   S3Client,
 } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { FileDomain } from '../enums/s3.enum';
@@ -54,7 +56,7 @@ export class S3Service {
 
     try {
       await this.s3Client.send(command);
-      return `https://s3.${this.region}.amazonaws.com/${this.bucketName}/${key}`;
+      return key;
     } catch (error) {
       this.logger.error('S3 Upload Error', error);
       throw new S3UploadFailException();
@@ -73,5 +75,13 @@ export class S3Service {
       this.logger.error('S3 Delete Error', error);
       throw new S3DeleteFailException();
     }
+  }
+
+  async getPresignedUrl(key: string, expiresIn = 3600): Promise<string> {
+    const command = new GetObjectCommand({
+      Bucket: this.bucketName,
+      Key: key,
+    });
+    return await getSignedUrl(this.s3Client, command, { expiresIn });
   }
 }

--- a/src/user/user.entity.ts
+++ b/src/user/user.entity.ts
@@ -20,7 +20,7 @@ export class User extends BaseEntity {
   contact: string | null;
 
   @Column({ type: 'varchar', nullable: true })
-  image: string | null;
+  image: string;
 
   @Column({
     type: 'enum',

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { UserNotFoundException } from 'src/user/exceptions/user-not-found.exception';
 import { Repository } from 'typeorm';
 import { CreateUserRequestDto } from './dto/request/create-user-request.dto';
 import { UpdateUserProfileRequestDto } from './dto/request/update-user-request.dto';
@@ -36,17 +35,12 @@ export class UserRepository {
   async updateUserProfile(
     userId: number,
     dto: UpdateUserProfileRequestDto,
-    imageUrl?: string | null,
+    imageKey?: string | null,
   ) {
-    const user = await this.findOneById(userId);
+    const updateData =
+      imageKey !== undefined ? { ...dto, image: imageKey } : { ...dto };
 
-    if (!user) {
-      throw new UserNotFoundException();
-    }
-
-    user.updateProfile(dto.nickname, dto.contact, imageUrl);
-
-    await this.repository.save(user);
+    return await this.repository.update(userId, updateData);
   }
 
   async updateUserImage(userId: number, imageUrl: string): Promise<void> {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -127,7 +127,7 @@ export class UserService {
       throw new UserNotFoundException();
     }
 
-    if (oldImageKey !== newImageKey) {
+    if (oldImageKey && oldImageKey !== newImageKey) {
       await this.s3Service.deleteFile(oldImageKey);
     }
   }


### PR DESCRIPTION
## 개요

- S3 자원을 Public하게 설정하지 않았기에 외부 접근이 불가했습니다.
- 이를 SignedUrl 방식을 통해 해결했습니다.
- 백엔드에서 S3에 SignedUrl을 요청해서 받고, 해당 Url을 response로 전달하도록 변경했습니다.
- SignedUrl은 발급한 이후로 정해진 만료 시간까지만 유효합니다. (현재는 1시간)

## 작업사항

- S3Service에 SignedUrl을 요청하는 함수를 구현
- User 또는 Collection 이미지는 앞으로 Key값을 저장
- User 프로필 수정 시, 이미지가 오지 않을 경우에는 기존 이미지 유지하도록 수정
- User/Collection 이미지와 관련된 응답으로 SignedUrl을 전달하도록 변경

## 주의사항

- 현재는 최대한 기능이 돌아가는 방향으로 개발을 진행했습니다.
- 추후 시간 여유가 되는대로 리팩토링을 진행하겠습니다.
