### PR TITLE
Feat: 최근에 추가된 컨텐츠 목록 조회 시 limit를 Query로 받도록 수정

### DIFF
--- a/src/collection/collection-content.repository.ts
+++ b/src/collection/collection-content.repository.ts
@@ -12,6 +12,7 @@ export class CollectionContentRepository {
 
   async findRecentContentsByUserId(
     userId: number,
+    limit: number,
   ): Promise<CollectionContent[]> {
     return this.collectionContentRepository
       .createQueryBuilder('collectionContent')
@@ -19,6 +20,7 @@ export class CollectionContentRepository {
       .leftJoinAndSelect('collectionContent.content', 'content')
       .where('collection.userId = :userId', { userId })
       .orderBy('collectionContent.createdAt', 'DESC')
+      .limit(limit)
       .getMany();
   }
 }

--- a/src/content/content.controller.ts
+++ b/src/content/content.controller.ts
@@ -1,8 +1,9 @@
-import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOkResponse,
   ApiOperation,
+  ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth/jwt-auth.guard';
@@ -17,14 +18,26 @@ export class ContentController {
 
   @ApiBearerAuth()
   @ApiOperation({ summary: '회원의 전체 컬렉션에서 최근 추가된 컨텐츠 조회' })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    example: 5,
+    description: '최대 결과 개수 (기본 10)',
+  })
   @ApiOkResponse({
     description: '최근 추가된 컨텐츠 목록 및 개수 반환',
     type: LatestContentsResponseDto,
   })
   @UseGuards(JwtAuthGuard)
   @Get('latest')
-  async findRecentContentsByUser(@Req() req: RequestWithUser) {
+  async findRecentContentsByUser(
+    @Req() req: RequestWithUser,
+    @Query('limit') limit: number = 10,
+  ) {
     const userId = req.user.id;
-    return await this.contentService.getRecentContentsAddedByUser(userId);
+    return await this.contentService.getRecentContentsAddedByUser(
+      userId,
+      limit,
+    );
   }
 }

--- a/src/content/content.service.ts
+++ b/src/content/content.service.ts
@@ -10,9 +10,13 @@ export class ContentService {
 
   async getRecentContentsAddedByUser(
     userId: number,
+    limit: number,
   ): Promise<LatestContentsResponseDto> {
     const collectionContents =
-      await this.collectionContentRepository.findRecentContentsByUserId(userId);
+      await this.collectionContentRepository.findRecentContentsByUserId(
+        userId,
+        limit,
+      );
     const contents = collectionContents.map((cc) => cc.content.toSummaryDto());
     return new LatestContentsResponseDto(contents);
   }


### PR DESCRIPTION
## 개요

- 최근에 컬렉션에 추가된 컨텐츠 목록 조회 요청 시에 limit를 Query로 받을 수 있게 변경했습니다.

## 작업사항

- limit를 받도록 변경했으며, limit는 기본값 10으로 설정했습니다.