### PR TITLE
Docs: 속성타입 변경

### DIFF
--- a/src/content/dto/genre-pagination-query.dto.ts
+++ b/src/content/dto/genre-pagination-query.dto.ts
@@ -6,7 +6,7 @@ import { PaginationQueryDto } from 'src/content/dto/pagination-query.dto';
 export class GenrePaginationQueryDto extends PaginationQueryDto {
   @ApiProperty({
     description: '장르 ID (단일 또는 다중)',
-    type: [Number],
+    type: Number,
     isArray: true,
     example: [28, 12],
   })


### PR DESCRIPTION
## 개요

- Swagger 상의 영화 / TV 시리즈 조회 API 파트에서 장르를 제대로 입력받지 못하던 이슈를 해결했습니다.

## 작업사항

- ApiProperty의 type을 `[Number]` -> `Number`로 변경했습니다.