### PR TITLE
Refactor: 표시 필드를 'displayTitle'로 통일

### DIFF
--- a/src/content/movie/entities/movie.entity.ts
+++ b/src/content/movie/entities/movie.entity.ts
@@ -55,7 +55,7 @@ export class Movie extends Content {
     return new ContentSummaryDto({
       id: this.id,
       posterPath: this.posterPath ?? '',
-      title: this.title,
+      title: this.displayTitle,
       contentType: this.type,
     });
   }

--- a/src/content/tv-series/dto/tv-series-detail-response.dto.ts
+++ b/src/content/tv-series/dto/tv-series-detail-response.dto.ts
@@ -155,7 +155,7 @@ export class TvSeriesDetailResponseDto {
   constructor(tv: TvSeries) {
     this.id = tv.id;
     this.contentType = tv.type;
-    this.title = tv.title;
+    this.title = tv.displayTitle;
     this.overview = tv.overview;
     this.posterPath = tv.posterPath;
     this.backdropPath = tv.backdropPath;

--- a/src/content/tv-series/entities/tv-series.entity.ts
+++ b/src/content/tv-series/entities/tv-series.entity.ts
@@ -72,7 +72,7 @@ export class TvSeries extends Content {
     return new ContentSummaryDto({
       id: this.id,
       posterPath: this.posterPath ?? '',
-      title: this.title,
+      title: this.displayTitle,
       contentType: this.type,
     });
   }


### PR DESCRIPTION
## 개요

-  응답 DTO 필드명(`title` -> `displayTitle`) 변경을 통해 콘텐츠 제목 표시 로직의 일관성을 확보

## 작업사항
- Movie 엔티티 `toSummaryDto()` 메서드에서 `title` 필드를 `this.displayTitle`로 변경하여 게터 값을 사용하도록 수정
- `MovieListResponseDto`, ` TvSeriesListResponseDto`, 에서 `title` 필드를 `displayTitle`로 변경