### PR TITLE
Fix: 영화/TV시리즈 목록 조회 시, 제목에 displayTitle이 반영되도록 수정

### DIFF
--- a/src/content/movie/dto/movie-list-item.dto.ts
+++ b/src/content/movie/dto/movie-list-item.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Expose } from 'class-transformer';
+import { Expose, Transform } from 'class-transformer';
+import { Movie } from '../entities/movie.entity';
 
 export class MovieListItemDto {
   @Expose()
@@ -10,6 +11,9 @@ export class MovieListItemDto {
   id: number;
 
   @Expose()
+  @Transform(({ obj }: { obj: Movie }) => obj.displayTitle, {
+    toClassOnly: true,
+  })
   @ApiProperty({ description: '영화 제목', example: 'Interstellar' })
   title: string;
 

--- a/src/content/tv-series/dto/tv-series-list-item.dto.ts
+++ b/src/content/tv-series/dto/tv-series-list-item.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Expose } from 'class-transformer';
+import { Expose, Transform } from 'class-transformer';
+import { TvSeries } from '../entities/tv-series.entity';
 
 export class TvSeriesListItemDto {
   @Expose()
@@ -8,6 +9,9 @@ export class TvSeriesListItemDto {
 
   @Expose()
   @ApiProperty({ description: 'TV 시리즈 제목', example: 'Game of Thrones' })
+  @Transform(({ obj }: { obj: TvSeries }) => obj.displayTitle, {
+    toClassOnly: true,
+  })
   title: string;
 
   @Expose()


### PR DESCRIPTION
## 개요

- 영화/TV시리즈 목록 조회 시, 제목에 displayTitle이 아닌, title이 적용되던 것을 수정했습니다.

## 작업사항

- `class-transformer`를 활용하여 title에 displayTitle이 적용되도록 했습니다.