### PR TITLE
Feat: Prometheus 및 Grafana를 통한 모니터링과 배포 자동화 적용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,10 @@ jobs:
           echo "MOVIE_MIN_VOTES_REQUIRED=${{ vars.MOVIE_MIN_VOTES_REQUIRED }}" >> .env
           echo "TV_SERIES_GLOBAL_AVERAGE_RATING=${{ vars.TV_SERIES_GLOBAL_AVERAGE_RATING }}" >> .env
           echo "TV_SERIES_MIN_VOTES_REQUIRED=${{ vars.TV_SERIES_MIN_VOTES_REQUIRED }}" >> .env
+          echo "GF_SERVER_DOMAIN=${{ vars.GF_SERVER_DOMAIN }}" >> .env
+          echo "GF_SERVER_ROOT_URL=${{ vars.GF_SERVER_ROOT_URL }}" >> .env
+          echo "GF_SERVER_SERVE_FROM_SUB_PATH=true" >> .env
+          echo "GF_SECURITY_ADMIN_PASSWORD=${{ secrets.GF_SECURITY_ADMIN_PASSWORD }}" >> .env
 
       - name: Create application artifact
         run: |
@@ -87,6 +91,8 @@ jobs:
               "aws s3 cp s3://s3-tastebox/backend/app.tar.gz .",
               "tar -xzf app.tar.gz -C ./TasteBox/TasteBox-Backend",
               "mv ./TasteBox/TasteBox-Backend/docker-compose.yml ./TasteBox/docker-compose.yml",
+              "mkdir -p ./TasteBox/prometheus",
+              "mv ./TasteBox/TasteBox-Backend/prometheus/prometheus.yml ./TasteBox/prometheus/prometheus.yml",
               "aws s3 cp s3://s3-tastebox/backend/.env ./TasteBox/TasteBox-Backend/.env",
               "rm app.tar.gz",
               "cd /home/ubuntu/TasteBox",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,25 @@ services:
     env_file:
       - ./TasteBox-Scheduler/.env
     restart: always
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: tastebox-prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    restart: always
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: tastebox-grafana
+    ports:
+      - "3001:3000"
+    env_file:
+      - ./TasteBox-Backend/.env
+    volumes:
+      - ./grafana/data:/var/lib/grafana
+    depends_on:
+      - prometheus
+    restart: always

--- a/infra/ec2-user-data/ssl-setup.md
+++ b/infra/ec2-user-data/ssl-setup.md
@@ -5,7 +5,7 @@
 - 도메인 DNS A 레코드가 EC2의 Public IP를 정확히 가리키고 있어야 합니다.
 - DNS 전파가 완료되었는지 `ping 도메인` 또는 `nslookup`으로 확인하세요.
 
-## 2. 다음을 수행 (certbot 설치가 되었음을 가정) - 도메인에 대한 SSL 인증서 발급
+## 2. 다음을 수행 (certbot 설치가 되었음을 가정) - 도메인에 대한 SSL 인증서 발급 (api, grafana 각각 발급)
 
 sudo certbot --nginx -d 도메인 --non-interactive --agree-tos -m your@email.com --redirect || true
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@nestjs/swagger": "^11.2.0",
         "@nestjs/typeorm": "^11.0.0",
         "@types/cookie-parser": "^1.4.9",
+        "@willsoto/nestjs-prometheus": "^6.0.2",
         "argon2": "^0.43.0",
         "axios": "^1.10.0",
         "bcrypt": "^6.0.0",
@@ -39,9 +40,11 @@
         "passport-jwt": "^4.0.1",
         "passport-kakao": "^1.0.1",
         "passport-local": "^1.0.0",
+        "prom-client": "^15.1.3",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
-        "typeorm": "^0.3.25"
+        "typeorm": "^0.3.25",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.0.6",
@@ -3993,6 +3996,15 @@
         "npm": ">=5.10.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
@@ -5771,6 +5783,16 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@willsoto/nestjs-prometheus": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@willsoto/nestjs-prometheus/-/nestjs-prometheus-6.0.2.tgz",
+      "integrity": "sha512-ePyLZYdIrOOdlOWovzzMisIgviXqhPVzFpSMKNNhn6xajhRHeBsjAzSdpxZTc6pnjR9hw1lNAHyKnKl7lAPaVg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "prom-client": "^15.0.0"
+      }
+    },
     "node_modules/@xhmikosr/archive-type": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@xhmikosr/archive-type/-/archive-type-7.0.0.tgz",
@@ -6891,6 +6913,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -13130,6 +13158,19 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -14401,6 +14442,15 @@
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/terser": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@nestjs/swagger": "^11.2.0",
     "@nestjs/typeorm": "^11.0.0",
     "@types/cookie-parser": "^1.4.9",
+    "@willsoto/nestjs-prometheus": "^6.0.2",
     "argon2": "^0.43.0",
     "axios": "^1.10.0",
     "bcrypt": "^6.0.0",
@@ -51,9 +52,11 @@
     "passport-jwt": "^4.0.1",
     "passport-kakao": "^1.0.1",
     "passport-local": "^1.0.0",
+    "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
-    "typeorm": "^0.3.25"
+    "typeorm": "^0.3.25",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.6",

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'backend'
+    static_configs:
+      - targets: ['tastebox-backend:3000']
+      

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,12 +1,17 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { APP_FILTER } from '@nestjs/core';
+import { APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core';
+import {
+  makeHistogramProvider,
+  PrometheusModule,
+} from '@willsoto/nestjs-prometheus';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { CollectionModule } from './collection/collection.module';
 import { DatabaseModule } from './common/database/database.module';
 import { HttpExceptionFilter } from './common/filters/http-exception.filter';
+import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 import { ContentModule } from './content/content.module';
 import { GenreModule } from './genre/genre.module';
 import { PreferenceModule } from './preference/preference.module';
@@ -18,6 +23,7 @@ import { UserModule } from './user/user.module';
       isGlobal: true,
       envFilePath: '.env',
     }),
+    PrometheusModule.register(),
     DatabaseModule,
     AuthModule,
     UserModule,
@@ -34,6 +40,16 @@ import { UserModule } from './user/user.module';
       provide: APP_FILTER,
       useClass: HttpExceptionFilter,
     },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: LoggingInterceptor,
+    },
+    makeHistogramProvider({
+      name: 'http_request_duration_seconds',
+      help: 'HTTP request duration in seconds',
+      labelNames: ['method', 'path', 'status'],
+      buckets: [0.1, 0.5, 1, 2, 5],
+    }),
   ],
 })
 export class AppModule {}

--- a/src/common/interceptors/logging.interceptor.ts
+++ b/src/common/interceptors/logging.interceptor.ts
@@ -1,0 +1,72 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  NestInterceptor,
+} from '@nestjs/common';
+import { InjectMetric } from '@willsoto/nestjs-prometheus';
+import { Histogram } from 'prom-client';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { v4 as uuidv4 } from 'uuid';
+
+@Injectable()
+export class LoggingInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(LoggingInterceptor.name);
+
+  constructor(
+    @InjectMetric('http_request_duration_seconds')
+    private readonly httpRequestDuration: Histogram<string>,
+  ) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    if (context.getType() === 'http') {
+      return this.logHttpCall(context, next);
+    }
+    return next.handle();
+  }
+
+  private logHttpCall(context: ExecutionContext, next: CallHandler) {
+    const request = context.switchToHttp().getRequest();
+    const userAgent = request.get('user-agent') || '';
+    const { ip, method, path: url } = request;
+    const correlationKey = uuidv4();
+    const userId = request.user?.userId;
+
+    let routePattern = url;
+    if (request.route?.path) {
+      routePattern = request.baseUrl
+        ? request.baseUrl + request.route.path
+        : request.route.path;
+    }
+
+    this.logger.log(
+      `[${correlationKey}] ${method} ${routePattern} ${userId} ${userAgent} ${ip}: ${context.getClass().name} ${context.getHandler().name}`,
+    );
+
+    const now = process.hrtime();
+
+    return next.handle().pipe(
+      tap(() => {
+        const response = context.switchToHttp().getResponse();
+        const { statusCode } = response;
+        const contentLength = response.get('content-length');
+        const diff = process.hrtime(now);
+        const durationInSeconds = diff[0] + diff[1] / 1e9;
+
+        this.httpRequestDuration
+          .labels(
+            method,
+            routePattern,
+            statusCode ? statusCode.toString() : 'unknown',
+          )
+          .observe(durationInSeconds);
+
+        this.logger.log(
+          `[${correlationKey}] ${method} ${routePattern} ${statusCode} ${contentLength}: ${Math.round(durationInSeconds * 1000)}ms`,
+        );
+      }),
+    );
+  }
+}


### PR DESCRIPTION
## 개요

- API 서버로 들어오는 요청에 대해 로깅을 적용하였으며, Prometheus를 통하여 수집해서 Grafana로 시각화할 수 있도록 했습니다.

## 작업사항

- LoggingIntercepter(엔드포인트 요청 수집 역할) 전역 적용했습니다.
- Prometheus와 Grafana 컨테이너를 생성하도록 docker-compose.yml에 컨테이너 설정을 추가했습니다.
- EC2 사용자 데이터에 Grafana 관련 nginx 설정 추가
- 배포 스크립트(Github Action Workflow)에 환경변수를 추가했습니다.

## 주의사항

- 컨테이너가 재시작되더라도 Grafana 설정이 유지되도록 EC2 내 디렉토리에 볼륨을 마운트시켜놨습니다. (EC2 제거가 아닌 이상 유지)
- Grafana의 Dashboard에서 Panel 설정들을 해야합니다.
